### PR TITLE
Add project-root context binding for agent identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .venv/
 .env
+config.toml

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install: ## Install all dependencies via uv
 	uv sync --all-extras
 
 dev: ## Start dev server with hot reload
-	uv run uvicorn deckhand.main:app --app-dir src --reload --host 127.0.0.1 --port 8000
+	uv run python -m uvicorn deckhand.main:app --app-dir src --reload --host 127.0.0.1 --port 8000
 
 test: ## Run test suite
 	uv run pytest tests/ -v --asyncio-mode=auto

--- a/config.example.toml
+++ b/config.example.toml
@@ -28,9 +28,6 @@ modules = [
 #   { key = "your-write-key-here", scope = "write" },
 #   { key = "your-read-key-here", scope = "read" },
 # ]
-#
-# Legacy single-key format (treated as write scope):
-# api_key = "your-secret-key"
 
 [rate_limit]
 # Maximum requests per minute per client IP (default: 60)

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_dashboard.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_dashboard.py
@@ -49,8 +49,8 @@ class AgentDashboardHandler:
         pass
 
     async def on_deckhand_event(self, ws: websockets.asyncio.client.ClientConnection, event_type: str, event: dict[str, Any], all_contexts: dict[str, dict[str, Any]]) -> None:
-        """Refresh dashboard on any agent status change."""
-        if event_type != "agent.status_changed":
+        """Refresh dashboard on any agent status or context change."""
+        if event_type not in ("agent.status_changed", "agent.context_changed"):
             return
 
         for context in list(self._contexts):

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_status.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_status.py
@@ -75,7 +75,8 @@ class AgentStatusHandler:
             agent = next((a for a in agents if a.get("id") == agent_id), None)
             if agent:
                 status = agent.get("status", "idle")
-                title = STATUS_TITLES.get(status, "") or agent.get("id", agent_id)
+                label = agent.get("display_label", agent.get("id", agent_id))
+                title = STATUS_TITLES.get(status, "") or label
                 await _set_state(ws, context, STATUS_INDEX.get(status, 0))
                 await _set_title(ws, context, title)
             else:
@@ -137,19 +138,21 @@ class AgentStatusHandler:
 
     async def on_deckhand_event(self, ws: websockets.asyncio.client.ClientConnection, event_type: str, event: dict[str, Any], all_contexts: dict[str, dict[str, Any]]) -> None:
         """Handle events from Deckhand Core."""
-        if event_type != "agent.status_changed":
+        if event_type not in ("agent.status_changed", "agent.context_changed"):
             return
 
         payload = event.get("payload", {})
-        agent_id = payload.get("agent_id", "")
-        new_status = payload.get("status", "")
+        agent_data = payload.get("agent", {})
+        agent_id = agent_data.get("id", "") or payload.get("agent_id", "")
+        new_status = agent_data.get("status", "") or payload.get("status", "")
+        display_label = agent_data.get("display_label", agent_id)
 
         for context, info in list(self._watched.items()):
             if info.get("agent_id") != agent_id:
                 continue
 
             state_idx = STATUS_INDEX.get(new_status, 0)
-            title = STATUS_TITLES.get(new_status, "") or agent_id
+            title = STATUS_TITLES.get(new_status, "") or display_label
 
             try:
                 await _set_state(ws, context, state_idx)

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/bridge.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/bridge.py
@@ -68,6 +68,48 @@ class DeckhandBridge:
         ) as resp:
             resp.raise_for_status()
 
+    async def register_agent(
+        self,
+        agent_id: str,
+        agent_type: str = "external",
+        capabilities: list[str] | None = None,
+        project_root: str | None = None,
+        active_file: str | None = None,
+    ) -> dict[str, Any]:
+        session = await self._get_session()
+        body: dict[str, Any] = {
+            "agent_id": agent_id,
+            "agent_type": agent_type,
+            "capabilities": capabilities or [],
+        }
+        if project_root is not None:
+            body["project_root"] = project_root
+        if active_file is not None:
+            body["active_file"] = active_file
+        async with session.post(
+            f"{self.base_url}/agents/register", json=body
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def update_agent_context(
+        self,
+        agent_id: str,
+        project_root: str | None = None,
+        active_file: str | None = None,
+    ) -> dict[str, Any]:
+        session = await self._get_session()
+        body: dict[str, Any] = {}
+        if project_root is not None:
+            body["project_root"] = project_root
+        if active_file is not None:
+            body["active_file"] = active_file
+        async with session.patch(
+            f"{self.base_url}/agents/{agent_id}/context", json=body
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
     # ----- HTTP: Actions -----
 
     async def execute_action(self, action_name: str, payload: dict[str, Any] | None = None) -> None:

--- a/src/deckhand/agents/base.py
+++ b/src/deckhand/agents/base.py
@@ -21,21 +21,45 @@ class AgentBase(ABC):
     """Base class for long-lived agents."""
 
     def __init__(
-        self, agent_id: str, agent_type: str, capabilities: Iterable[str]
+        self,
+        agent_id: str,
+        agent_type: str,
+        capabilities: Iterable[str],
+        project_root: Optional[str] = None,
+        active_file: Optional[str] = None,
     ) -> None:
         self.id = agent_id
         self.type = agent_type
         self.status = AgentStatus.IDLE
         self.capabilities = list(capabilities)
+        self.project_root = project_root
+        self.active_file = active_file
         self.on_event: Optional[EventHandler] = None
 
+    @property
+    def display_label(self) -> str:
+        """Context-aware label for UI display.
+
+        Returns a label like "Claude: feature-x" when project context is
+        available, falling back to the agent id.
+        """
+        if not self.project_root:
+            return self.id
+        # Use the last path component as a short project name
+        project_name = self.project_root.rstrip("/").rsplit("/", 1)[-1]
+        return f"{self.type}: {project_name}"
+
     def as_dict(self) -> dict[str, object]:
-        return {
+        d: dict[str, object] = {
             "id": self.id,
             "type": self.type,
             "status": self.status.value,
             "capabilities": self.capabilities,
+            "project_root": self.project_root,
+            "active_file": self.active_file,
+            "display_label": self.display_label,
         }
+        return d
 
     async def _set_status(self, status: AgentStatus) -> None:
         self.status = status

--- a/src/deckhand/agents/mock.py
+++ b/src/deckhand/agents/mock.py
@@ -10,11 +10,18 @@ from deckhand.orchestrator.events import build_event
 class MockAgent(AgentBase):
     """Simulates a simple lifecycle with input gating."""
 
-    def __init__(self, agent_id: str) -> None:
+    def __init__(
+        self,
+        agent_id: str,
+        project_root: Optional[str] = None,
+        active_file: Optional[str] = None,
+    ) -> None:
         super().__init__(
             agent_id=agent_id,
             agent_type="mock",
             capabilities=["accepts_text", "cancellable"],
+            project_root=project_root,
+            active_file=active_file,
         )
         self._task: Optional[asyncio.Task[None]] = None
         self._input_event = asyncio.Event()

--- a/src/deckhand/config/settings.py
+++ b/src/deckhand/config/settings.py
@@ -28,8 +28,10 @@ class Settings:
         # Auth: list of {key, scope} dicts
         self._raw_api_keys: list[dict[str, str]] = []
 
-        # Load from config file if specified
+        # Load from config file: explicit env var, or auto-discover ./config.toml
         config_file = os.getenv("DECKHAND_CONFIG_FILE")
+        if not config_file and os.path.exists("config.toml"):
+            config_file = "config.toml"
         if config_file:
             self.config_file_path = config_file
             self._load_from_config_file(config_file)
@@ -89,15 +91,9 @@ class Settings:
             self.rate_limit_rpm = rl_config.get("rpm", self.rate_limit_rpm)
 
     def _load_auth(self, auth_config: dict[str, Any]) -> None:
-        """Parse the [auth] section, supporting both legacy and new formats."""
-        # New format: api_keys = [{key = "...", scope = "..."}]
+        """Parse the [auth] section."""
         if "api_keys" in auth_config:
             self._raw_api_keys = auth_config["api_keys"]
-            return
-
-        # Legacy format: api_key = "single-key" (treated as write scope)
-        if api_key := auth_config.get("api_key"):
-            self._raw_api_keys = [{"key": api_key, "scope": "write"}]
 
     # ------------------------------------------------------------------
     # Environment variable overrides

--- a/src/deckhand/main.py
+++ b/src/deckhand/main.py
@@ -22,7 +22,7 @@ from starlette.responses import JSONResponse
 from deckhand.agents.mock import MockAgent
 from deckhand.config.settings import Settings
 from deckhand.orchestrator.actions import ActionRegistry
-from deckhand.orchestrator.events import build_error_event
+from deckhand.orchestrator.events import build_error_event, build_event
 from deckhand.orchestrator.manager import Orchestrator
 from deckhand.orchestrator.signals import SignalRegistry
 from deckhand.plugins.loader import load_plugins
@@ -85,8 +85,12 @@ async def lifespan(app: FastAPI):
 
     # Initialize orchestrator
     orchestrator = Orchestrator(state_persist_path=settings.state_file_path)
-    orchestrator.register_agent(MockAgent(agent_id="mock-1"))
-    orchestrator.register_agent(MockAgent(agent_id="mock-2"))
+    orchestrator.register_agent(
+        MockAgent(agent_id="mock-1", project_root="/home/dev/project-alpha")
+    )
+    orchestrator.register_agent(
+        MockAgent(agent_id="mock-2", project_root="/home/dev/project-beta")
+    )
 
     # Initialize registries
     action_registry = ActionRegistry(orchestrator)
@@ -207,6 +211,23 @@ class ActionPayload(BaseModel):
     payload: dict[str, object] = {}
 
 
+class AgentRegisterPayload(BaseModel):
+    """Payload for registering a new agent."""
+
+    agent_id: str
+    agent_type: str = "external"
+    capabilities: list[str] = []
+    project_root: str | None = None
+    active_file: str | None = None
+
+
+class AgentContextPayload(BaseModel):
+    """Payload for updating an agent's project context."""
+
+    project_root: str | None = None
+    active_file: str | None = None
+
+
 class SignalPayload(BaseModel):
     """Wrapper for signal webhook payloads."""
 
@@ -285,6 +306,67 @@ async def provide_input(agent_id: str, payload: InputPayload) -> dict[str, str]:
         )
         raise HTTPException(status_code=404, detail="agent not found") from exc
     return {"status": "input_sent"}
+
+
+@app.post("/agents/register", dependencies=[Depends(require_write)])
+async def register_agent(payload: AgentRegisterPayload) -> dict[str, object]:
+    """Register a new external agent with optional project context."""
+    if orchestrator is None:
+        raise HTTPException(status_code=503, detail="Service not initialized")
+
+    if orchestrator.get_agent(payload.agent_id) is not None:
+        raise HTTPException(status_code=409, detail="agent already registered")
+
+    from deckhand.agents.base import AgentBase, AgentStatus
+
+    class ExternalAgent(AgentBase):
+        """Placeholder agent for externally-managed processes."""
+
+        async def start(self) -> None:
+            await self._set_status(AgentStatus.RUNNING)
+
+        async def cancel(self) -> None:
+            await self._set_status(AgentStatus.IDLE)
+
+        async def provide_input(self, text: str) -> None:
+            pass
+
+    agent = ExternalAgent(
+        agent_id=payload.agent_id,
+        agent_type=payload.agent_type,
+        capabilities=payload.capabilities,
+        project_root=payload.project_root,
+        active_file=payload.active_file,
+    )
+    orchestrator.register_agent(agent)
+    return agent.as_dict()
+
+
+@app.patch("/agents/{agent_id}/context", dependencies=[Depends(require_write)])
+async def update_agent_context(
+    agent_id: str, payload: AgentContextPayload
+) -> dict[str, object]:
+    """Update an agent's project context (project_root and/or active_file)."""
+    if orchestrator is None:
+        raise HTTPException(status_code=503, detail="Service not initialized")
+
+    agent = orchestrator.get_agent(agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="agent not found")
+
+    if payload.project_root is not None:
+        agent.project_root = payload.project_root
+    if payload.active_file is not None:
+        agent.active_file = payload.active_file
+
+    await orchestrator.event_bus.emit(
+        build_event(
+            "agent.context_changed",
+            {"kind": "agent", "id": agent_id},
+            {"agent": agent.as_dict()},
+        )
+    )
+    return agent.as_dict()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -36,7 +36,7 @@ async def client(monkeypatch):
 
 
 async def test_list_agents(client: AsyncClient) -> None:
-    """Bridge.list_agents() hits GET /agents."""
+    """Bridge.list_agents() hits GET /agents and includes context fields."""
     resp = await client.get("/agents")
     assert resp.status_code == 200
     agents = resp.json()
@@ -45,6 +45,13 @@ async def test_list_agents(client: AsyncClient) -> None:
     ids = [a["id"] for a in agents]
     assert "mock-1" in ids
     assert "mock-2" in ids
+
+    # Verify context fields are present
+    mock1 = next(a for a in agents if a["id"] == "mock-1")
+    assert "project_root" in mock1
+    assert "display_label" in mock1
+    assert mock1["project_root"] == "/home/dev/project-alpha"
+    assert mock1["display_label"] == "mock: project-alpha"
 
 
 async def test_start_agent(client: AsyncClient) -> None:
@@ -133,3 +140,80 @@ async def test_read_only_key_blocks_write(client: AsyncClient) -> None:
     ) as bad:
         resp = await bad.post("/agents/mock-1/start")
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Agent registration & context tests
+# ---------------------------------------------------------------------------
+
+
+async def test_register_agent(client: AsyncClient) -> None:
+    """POST /agents/register creates a new agent with context."""
+    resp = await client.post(
+        "/agents/register",
+        json={
+            "agent_id": "ext-1",
+            "agent_type": "claude-code",
+            "capabilities": ["accepts_text"],
+            "project_root": "/home/dev/my-project",
+            "active_file": "/home/dev/my-project/src/main.py",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "ext-1"
+    assert data["type"] == "claude-code"
+    assert data["project_root"] == "/home/dev/my-project"
+    assert data["active_file"] == "/home/dev/my-project/src/main.py"
+    assert data["display_label"] == "claude-code: my-project"
+
+    # Agent should now be listable
+    resp2 = await client.get("/agents")
+    ids = [a["id"] for a in resp2.json()]
+    assert "ext-1" in ids
+
+
+async def test_register_agent_duplicate(client: AsyncClient) -> None:
+    """Registering an agent with an existing ID returns 409."""
+    resp = await client.post(
+        "/agents/register",
+        json={"agent_id": "mock-1"},
+    )
+    assert resp.status_code == 409
+
+
+async def test_update_agent_context(client: AsyncClient) -> None:
+    """PATCH /agents/{id}/context updates project_root and active_file."""
+    resp = await client.patch(
+        "/agents/mock-1/context",
+        json={
+            "project_root": "/tmp/new-project",
+            "active_file": "/tmp/new-project/README.md",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["project_root"] == "/tmp/new-project"
+    assert data["active_file"] == "/tmp/new-project/README.md"
+    assert data["display_label"] == "mock: new-project"
+
+
+async def test_update_agent_context_not_found(client: AsyncClient) -> None:
+    """PATCH /agents/{id}/context returns 404 for unknown agent."""
+    resp = await client.patch(
+        "/agents/nonexistent/context",
+        json={"project_root": "/tmp/x"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_agent_without_context_uses_id_as_label(client: AsyncClient) -> None:
+    """An agent with no project_root falls back to its ID for display_label."""
+    resp = await client.post(
+        "/agents/register",
+        json={"agent_id": "bare-agent"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["project_root"] is None
+    assert data["display_label"] == "bare-agent"


### PR DESCRIPTION
## Summary

Adds project context (project_root, active_file) to agents so multiple instances of the same agent type can be distinguished by workspace. The OpenDeck plugin now displays context-aware labels like "claude-code: my-project" instead of generic IDs like "mock-1".

## Changes

- **AgentBase**: New `project_root` and `active_file` fields, plus a `display_label` property that derives a human-friendly label from the project root.
- **API**: New `POST /agents/register` (register external agents with context) and `PATCH /agents/{id}/context` (update context, emits `agent.context_changed` event).
- **Bridge**: `register_agent()` and `update_agent_context()` HTTP client methods.
- **OpenDeck plugin**: agent_status and agent_dashboard handlers use `display_label` and listen for `agent.context_changed` events.
- **Tests**: 5 new tests covering registration, duplicate detection, context updates, 404 handling, and label fallback.

## Drive-by fixes (in scope per user request)

- **Makefile**: `uv run uvicorn` → `uv run python -m uvicorn` (binary entry-point wasn't resolvable).
- **Config auto-discovery**: `Settings` now auto-loads `./config.toml` if `DECKHAND_CONFIG_FILE` isn't set.
- **Dropped legacy `api_key` field**: only `api_keys = [...]` is supported now (unreleased software, no migration needed).
- **`.gitignore`**: added `config.toml` to prevent committing local secrets.

Closes #2