### PR TITLE
Add GET /health endpoint

### DIFF
--- a/src/deckhand/main.py
+++ b/src/deckhand/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from contextlib import asynccontextmanager
 
 from fastapi import (
@@ -45,6 +46,9 @@ signal_registry: SignalRegistry | None = None
 plugin_registry: PluginRegistry | None = None
 settings: Settings | None = None
 rate_limiter: RateLimiter | None = None
+_service_start_time: float | None = None
+
+SERVICE_VERSION = "0.3.0"
 
 
 @asynccontextmanager
@@ -56,7 +60,10 @@ async def lifespan(app: FastAPI):
         signal_registry, \
         plugin_registry, \
         settings, \
-        rate_limiter
+        rate_limiter, \
+        _service_start_time
+
+    _service_start_time = time.time()
 
     # Startup — load settings first so we can configure logging from them
     settings = Settings()
@@ -119,7 +126,7 @@ async def lifespan(app: FastAPI):
     logger.info("Shutting down Deckhand service...")
 
 
-app = FastAPI(title="Deckhand", version="0.3.0", lifespan=lifespan)
+app = FastAPI(title="Deckhand", version=SERVICE_VERSION, lifespan=lifespan)
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +254,48 @@ class SignalPayload(BaseModel):
     """Wrapper for signal webhook payloads."""
 
     payload: dict[str, object] = {}
+
+
+# ---------------------------------------------------------------------------
+# Health check (unauthenticated)
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health")
+async def health() -> dict[str, object]:
+    """Service health check. Unauthenticated for monitoring/orchestration."""
+    if (
+        orchestrator is None
+        or action_registry is None
+        or signal_registry is None
+        or settings is None
+        or _service_start_time is None
+    ):
+        raise HTTPException(status_code=503, detail="Service not initialized")
+
+    agents = orchestrator.list_agents()
+    state_store = orchestrator.state_store
+
+    return {
+        "status": "ok",
+        "version": SERVICE_VERSION,
+        "uptime_seconds": time.time() - _service_start_time,
+        "websocket_clients": orchestrator.event_bus.client_count,
+        "agents": {
+            "count": len(agents),
+            "statuses": {a.id: a.status.value for a in agents},
+        },
+        "plugins": {
+            "modules": list(settings.plugin_modules),
+            "actions": len(action_registry.list_actions()),
+            "signals": len(signal_registry.list_signals()),
+        },
+        "state_store": {
+            "entry_count": state_store.entry_count(),
+            "persist_path": state_store.persist_path,
+            "writable": state_store.is_writable(),
+        },
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/deckhand/orchestrator/events.py
+++ b/src/deckhand/orchestrator/events.py
@@ -88,6 +88,10 @@ class EventBus:
     def __init__(self) -> None:
         self._subscribers: set[WebSocket] = set()
 
+    @property
+    def client_count(self) -> int:
+        return len(self._subscribers)
+
     async def subscribe(self, websocket: WebSocket, *, accept: bool = True) -> None:
         if accept:
             await websocket.accept()

--- a/src/deckhand/orchestrator/state.py
+++ b/src/deckhand/orchestrator/state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,28 @@ class StateStore:
         # Load persisted state on init
         if self._persist_path:
             self._load()
+
+    @property
+    def persist_path(self) -> str | None:
+        return str(self._persist_path) if self._persist_path else None
+
+    def entry_count(self) -> int:
+        self._purge_expired()
+        return len(self._state)
+
+    def is_writable(self) -> bool:
+        """Whether the state store can persist writes.
+
+        Returns True if no persist path is configured (in-memory is always
+        writable), or if the configured persist path's parent directory
+        exists and is writable.
+        """
+        if self._persist_path is None:
+            return True
+        parent = self._persist_path.parent
+        if not parent.exists():
+            return False
+        return os.access(parent, os.W_OK)
 
     def list_state(self) -> list[dict[str, Any]]:
         self._purge_expired()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -207,6 +207,24 @@ async def test_update_agent_context_not_found(client: AsyncClient) -> None:
     assert resp.status_code == 404
 
 
+async def test_health_endpoint(client: AsyncClient) -> None:
+    """GET /health returns service health info and does not require auth."""
+    transport = ASGITransport(app=client._transport.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as no_auth:
+        resp = await no_auth.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert "version" in data
+    assert data["uptime_seconds"] >= 0
+    assert data["websocket_clients"] == 0
+    assert data["agents"]["count"] >= 2
+    assert "mock-1" in data["agents"]["statuses"]
+    assert data["plugins"]["actions"] > 0
+    assert "entry_count" in data["state_store"]
+    assert data["state_store"]["writable"] is True
+
+
 async def test_agent_without_context_uses_id_as_label(client: AsyncClient) -> None:
     """An agent with no project_root falls back to its ID for display_label."""
     resp = await client.post(


### PR DESCRIPTION
Adds an unauthenticated `GET /health` endpoint for monitoring and container orchestration.

Response includes:
- Service uptime and version
- WebSocket client count
- Agent count and per-agent statuses
- Plugin modules, action count, signal count
- State store entry count, persist path, and writable check

Closes #6