### PR TITLE
Replace ScopedStateStore __getattr__ with explicit allow-list

### DIFF
--- a/src/deckhand/plugins/capabilities.py
+++ b/src/deckhand/plugins/capabilities.py
@@ -105,11 +105,25 @@ class ScopedSignalRegistry:
 
 
 class ScopedStateStore:
-    """StateStore proxy that enforces a capability level."""
+    """StateStore proxy that enforces a capability level.
+
+    This wrapper deliberately exposes an **explicit allow-list** of
+    ``StateStore`` methods. There is no ``__getattr__`` fallback: any new
+    method added to ``StateStore`` is invisible to plugins until it is
+    explicitly proxied here with the appropriate capability check. This
+    ensures that future write-capable methods (e.g. ``bulk_set``, ``purge``)
+    cannot silently be reached by ``read-only`` plugins.
+
+    When adding a new ``StateStore`` method, decide whether it is a read or
+    a write operation and add a corresponding proxy method below. Write
+    operations must guard against ``read-only`` via ``_deny``.
+    """
 
     def __init__(self, inner: StateStore, capability: Capability) -> None:
         self._inner = inner
         self._capability = capability
+
+    # --- read operations (allowed for all capability levels) ---
 
     def list_state(self) -> list[dict[str, Any]]:
         return self._inner.list_state()
@@ -117,8 +131,13 @@ class ScopedStateStore:
     def entry_count(self) -> int:
         return self._inner.entry_count()
 
+    def get_state(self, key: str) -> dict[str, Any] | None:
+        return self._inner.get_state(key)
+
     def is_writable(self) -> bool:
         return self._capability != "read-only" and self._inner.is_writable()
+
+    # --- write operations (denied for read-only) ---
 
     async def set_state(self, *args: Any, **kwargs: Any) -> Any:
         if self._capability == "read-only":
@@ -129,15 +148,6 @@ class ScopedStateStore:
         if self._capability == "read-only":
             raise _deny(self._capability, "write state")
         return await self._inner.clear_state(*args, **kwargs)
-
-    def get_state(self, key: str) -> dict[str, Any] | None:
-        return self._inner.get_state(key)
-
-    def __getattr__(self, name: str) -> Any:
-        # Delegate any additional read helpers on StateStore
-        if name.startswith("_"):
-            raise AttributeError(name)
-        return getattr(self._inner, name)
 
 
 class ScopedEventBus:

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -55,6 +55,28 @@ async def test_read_only_denies_all_writes(
         await scoped.actions.run("agent.start", {"agent_id": "mock-1"})
 
 
+async def test_scoped_state_store_has_no_getattr_fallback(
+    plugin_registry: PluginRegistry,
+) -> None:
+    """ScopedStateStore must expose only its explicit allow-list.
+
+    If a future write-capable method is added to StateStore, it must not be
+    silently reachable through the scoped wrapper — plugins should get an
+    AttributeError until the method is explicitly proxied with the right
+    capability check. This test pins that contract.
+    """
+    scoped = build_scoped_registry(plugin_registry, "read-only")
+
+    # Simulate a hypothetical future write method on the underlying store.
+    async def bulk_set(entries: dict[str, object]) -> None:  # pragma: no cover
+        raise AssertionError("should not be reachable via scoped store")
+
+    plugin_registry.state.bulk_set = bulk_set  # type: ignore[attr-defined]
+
+    with pytest.raises(AttributeError):
+        _ = scoped.state.bulk_set  # type: ignore[attr-defined]
+
+
 async def test_state_only_allows_state_and_signals_but_not_actions(
     plugin_registry: PluginRegistry,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -198,7 +198,7 @@ wheels = [
 
 [[package]]
 name = "deckhand"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Removes the `__getattr__` catch-all on `ScopedStateStore` that delegated unknown attribute access to the underlying `StateStore`. The wrapper now exposes only an explicit allow-list of proxied methods (`list_state`, `entry_count`, `get_state`, `is_writable`, `set_state`, `clear_state`), so any future write-capable method added to `StateStore` (e.g. `bulk_set`, `purge`) is invisible to plugins until explicitly proxied with the correct capability check.

Audit of the current `StateStore` surface confirmed nothing was leaking today — all public methods were already explicitly proxied, and the prior `name.startswith("_")` guard blocked private attributes. This change closes the latent defense-in-depth gap flagged on PR #13.

Added a regression test that injects a hypothetical `bulk_set` onto the underlying store and asserts it is not reachable through the scoped wrapper.

Closes #14