### PR TITLE
Deny state-only plugins from invoking actions

### DIFF
--- a/src/deckhand/plugins/capabilities.py
+++ b/src/deckhand/plugins/capabilities.py
@@ -11,7 +11,8 @@ Capabilities (cumulative):
   orchestrator.
 - ``state-only``: everything in ``read-only`` plus state mutation, signal
   registration, and event emission. No orchestrator access and cannot
-  register actions (which by definition drive orchestrator commands).
+  register *or invoke* actions (which by definition drive orchestrator
+  commands).
 - ``full``: unrestricted access, equivalent to the raw ``PluginRegistry``.
 """
 
@@ -65,7 +66,7 @@ class ScopedActionRegistry:
         self._inner.register(name, handler, description, payload_schema)
 
     async def run(self, name: str, payload: dict[str, object]) -> None:
-        if self._capability == "read-only":
+        if self._capability != "full":
             raise _deny(self._capability, "run actions")
         await self._inner.run(name, payload)
 

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -101,6 +101,11 @@ async def test_state_only_allows_state_and_signals_but_not_actions(
     with pytest.raises(PermissionError):
         scoped.actions.register("evil.action", noop)
 
+    # Action invocation also denied — state-only must not reach orchestrator
+    # commands via the action layer.
+    with pytest.raises(PermissionError):
+        await scoped.actions.run("agent.start", {"agent_id": "mock-1"})
+
 
 async def test_load_plugins_with_spec(plugin_registry: PluginRegistry) -> None:
     load_plugins(


### PR DESCRIPTION
`ScopedActionRegistry.run()` previously denied only `read-only`, which allowed `state-only` plugins to invoke arbitrary registered actions (including orchestrator commands like `agent.start`). This contradicted the docstring intent that `state-only` has no orchestrator access.

Tightens `run()` to require `full` capability, clarifies the `state-only` docstring bullet to say "cannot register *or invoke* actions", and extends the state-only test to pin the new behavior.

Closes #15