### PR TITLE
agents.pending_input state + focus_next_pending action for iTerm

### DIFF
--- a/examples/claude_code_hooks.json
+++ b/examples/claude_code_hooks.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Drop the `hooks` block below into ~/.claude/settings.json (merging with any existing hooks) to reflect your Claude Code session state into Deckhand. Each hook reads the JSON payload Claude Code writes to stdin and forwards it to Deckhand's /agents/claude-code/hook endpoint. Replace DECKHAND_URL and DECKHAND_API_KEY with your values (or set them as env vars in your shell profile).",
+  "_comment": "Drop the `hooks` block below into ~/.claude/settings.json (merging with any existing hooks) to reflect your Claude Code session state into Deckhand. Each hook reads the JSON payload Claude Code writes to stdin and forwards it to Deckhand's /agents/claude-code/hook endpoint, adding `iterm_session_id` from the shell's $ITERM_SESSION_ID (iTerm sets that automatically; outside iTerm it's null and the agent is tracked but not focusable). Replace DECKHAND_URL and DECKHAND_API_KEY with your values (or set them as env vars in your shell profile).",
   "_requires": "curl, jq",
   "hooks": {
     "SessionStart": [
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -c . | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
+            "command": "jq -c '. + {iterm_session_id: env.ITERM_SESSION_ID}' | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -c . | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
+            "command": "jq -c '. + {iterm_session_id: env.ITERM_SESSION_ID}' | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -c . | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
+            "command": "jq -c '. + {iterm_session_id: env.ITERM_SESSION_ID}' | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
           }
         ]
       }
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -c . | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
+            "command": "jq -c '. + {iterm_session_id: env.ITERM_SESSION_ID}' | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
           }
         ]
       }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -c . | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
+            "command": "jq -c '. + {iterm_session_id: env.ITERM_SESSION_ID}' | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
           }
         ]
       }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -c . | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
+            "command": "jq -c '. + {iterm_session_id: env.ITERM_SESSION_ID}' | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/claude-code/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
           }
         ]
       }

--- a/src/deckhand/agents/pending_input.py
+++ b/src/deckhand/agents/pending_input.py
@@ -1,0 +1,90 @@
+"""Derived state: which agents are currently ``awaiting_input``.
+
+Subscribes to the event bus and maintains two state keys:
+
+- ``agents.pending_input`` → ``{"agent_ids": [...]}`` in insertion order
+  (the agent who entered ``awaiting_input`` first appears first).
+- ``agents.pending_input_count`` → ``{"count": N}`` — the same length,
+  exposed as a separate key so a Stream Deck button can bind a simple
+  numeric formatter without parsing the list.
+
+The tracker observes ``agent.status_changed`` (to add / remove agents)
+and ``agent.unregistered`` (to drop sessions that ended mid-wait). State
+is rebuilt in-memory from scratch on each Deckhand restart; the first
+relevant event after restart re-populates the keys.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from deckhand.orchestrator.state import StateStore
+
+logger = logging.getLogger(__name__)
+
+_AWAITING_INPUT = "awaiting_input"
+
+
+class PendingInputTracker:
+    """EventBus listener that derives the pending-input state keys."""
+
+    STATE_LIST_KEY = "agents.pending_input"
+    STATE_COUNT_KEY = "agents.pending_input_count"
+
+    def __init__(self, state_store: StateStore) -> None:
+        self._state_store = state_store
+        # Insertion-ordered: first agent to enter awaiting_input is first out.
+        self._pending: list[str] = []
+
+    @property
+    def pending_ids(self) -> list[str]:
+        """Snapshot of the current pending list (oldest first)."""
+        return list(self._pending)
+
+    async def __call__(self, event: dict[str, Any]) -> None:
+        event_type = event.get("type")
+        if event_type == "agent.status_changed":
+            await self._handle_status(event)
+        elif event_type == "agent.unregistered":
+            await self._handle_unregistered(event)
+
+    async def _handle_status(self, event: dict[str, Any]) -> None:
+        payload = event.get("payload") or {}
+        agent = payload.get("agent") or {}
+        agent_id = agent.get("id")
+        status = agent.get("status")
+        if not agent_id or not status:
+            return
+
+        if status == _AWAITING_INPUT:
+            if agent_id in self._pending:
+                return  # already tracked
+            self._pending.append(agent_id)
+        else:
+            if agent_id not in self._pending:
+                return
+            self._pending.remove(agent_id)
+
+        await self._publish()
+
+    async def _handle_unregistered(self, event: dict[str, Any]) -> None:
+        payload = event.get("payload") or {}
+        agent_id = payload.get("agent_id")
+        if not agent_id or agent_id not in self._pending:
+            return
+        self._pending.remove(agent_id)
+        await self._publish()
+
+    async def _publish(self) -> None:
+        source = {"kind": "tracker", "id": "agents.pending_input"}
+        await self._state_store.set_state(
+            self.STATE_LIST_KEY,
+            {"agent_ids": list(self._pending)},
+            source=source,
+        )
+        await self._state_store.set_state(
+            self.STATE_COUNT_KEY,
+            {"count": len(self._pending)},
+            source=source,
+        )

--- a/src/deckhand/focusers/__init__.py
+++ b/src/deckhand/focusers/__init__.py
@@ -1,0 +1,9 @@
+"""Platform-specific focuser primitives.
+
+A focuser is an async, no-arg callable that brings a specific window/tab
+to the foreground on the local machine when invoked. Each platform
+target (iTerm, Cursor, browser tabs) lives in its own submodule. The
+orchestrator's :class:`~deckhand.orchestrator.focusers.FocuserRegistry`
+stores them keyed by agent id; the ``agents.focus_next_pending`` action
+looks them up at press time.
+"""

--- a/src/deckhand/focusers/iterm.py
+++ b/src/deckhand/focusers/iterm.py
@@ -1,0 +1,93 @@
+"""iTerm2 tab focuser via AppleScript.
+
+We use ``osascript`` rather than the iTerm2 Python API because:
+
+* No dependency on the user enabling iTerm's Python runtime.
+* Zero new Python dependencies (``osascript`` ships with macOS).
+* iTerm's AppleScript surface is stable and the per-session UUID is
+  exposed as ``id of <session>``.
+* Easy to mock in tests (one ``subprocess.run`` call).
+
+iTerm sets ``$ITERM_SESSION_ID`` automatically in every shell session it
+spawns; the Claude Code hook payload reads that env var and forwards it
+as ``iterm_session_id``. When the user runs Claude outside iTerm the
+field is absent, no focuser is registered, and the agent simply shows
+up as not-focusable in the pending-input queue.
+
+The AppleScript walks every window/tab/session, matches on the supplied
+session UUID, activates iTerm, and selects the containing window + tab.
+``do shell script "true"`` at the end suppresses AppleScript's default
+echo so the subprocess returns cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# iTerm session UUIDs include a colon-separated tty hint after the UUID
+# (e.g. "w0t1p0:UUID"); we strip everything before the last colon so the
+# script matches on the raw UUID. Real session ids in our test corpus
+# don't contain that prefix but stripping is cheap and defensive.
+
+
+def _build_applescript(iterm_session_id: str) -> str:
+    # AppleScript itself does the matching so we don't have to parse iTerm
+    # output. ``contains`` matches the trailing UUID even if iTerm reports
+    # the longer ``w0t1p0:UUID`` form.
+    safe_id = iterm_session_id.replace('"', '\\"')
+    return f'''
+        tell application "iTerm2"
+            activate
+            repeat with theWindow in windows
+                repeat with theTab in tabs of theWindow
+                    repeat with theSession in sessions of theTab
+                        if (id of theSession as string) contains "{safe_id}" then
+                            select theWindow
+                            tell theWindow to select theTab
+                            tell theTab to select theSession
+                            return
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+        end tell
+    '''
+
+
+def make_iterm_focuser(iterm_session_id: str):
+    """Build an async focuser callable for a specific iTerm session UUID."""
+
+    script = _build_applescript(iterm_session_id)
+
+    async def focuser() -> None:
+        await asyncio.to_thread(_run_osascript, script, iterm_session_id)
+
+    return focuser
+
+
+def _run_osascript(script: str, session_id: str) -> None:
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except FileNotFoundError:
+        logger.warning("osascript not available; iTerm focuser is a no-op")
+        return
+    except subprocess.TimeoutExpired:
+        logger.warning("iTerm focuser timed out for session %s", session_id)
+        return
+
+    if result.returncode != 0:
+        logger.warning(
+            "iTerm focuser exited %s for session %s: %s",
+            result.returncode,
+            session_id,
+            (result.stderr or "").strip(),
+        )

--- a/src/deckhand/focusers/iterm.py
+++ b/src/deckhand/focusers/iterm.py
@@ -34,11 +34,25 @@ logger = logging.getLogger(__name__)
 # don't contain that prefix but stripping is cheap and defensive.
 
 
+def _escape_for_applescript(raw: str) -> str:
+    """Make ``raw`` safe to embed inside an AppleScript double-quoted string.
+
+    Strips control characters (anything below 0x20), then escapes
+    backslashes and double quotes. Backslash escaping must happen first;
+    otherwise the backslash we add to escape a quote would itself be
+    re-escaped. Control characters are dropped rather than encoded so a
+    pasted newline cannot smuggle a second AppleScript statement past the
+    closing quote.
+    """
+    stripped = "".join(ch for ch in raw if ord(ch) >= 0x20)
+    return stripped.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _build_applescript(iterm_session_id: str) -> str:
     # AppleScript itself does the matching so we don't have to parse iTerm
     # output. ``contains`` matches the trailing UUID even if iTerm reports
     # the longer ``w0t1p0:UUID`` form.
-    safe_id = iterm_session_id.replace('"', '\\"')
+    safe_id = _escape_for_applescript(iterm_session_id)
     return f'''
         tell application "iTerm2"
             activate

--- a/src/deckhand/main.py
+++ b/src/deckhand/main.py
@@ -545,9 +545,11 @@ async def claude_code_hook(payload: ClaudeCodeHookPayload) -> dict[str, object]:
         agent = existing  # type: ignore[assignment]
         if payload.cwd and agent.project_root != payload.cwd:
             agent.project_root = payload.cwd
-        # Late-arriving iterm_session_id (e.g. user upgraded their hook
-        # script mid-session) — register the focuser if missing.
-        if payload.iterm_session_id and agent_id not in orchestrator.focusers:
+        # Always (re)bind the focuser when iterm_session_id is present, so
+        # late-arriving hook upgrades AND changes to the iTerm session id
+        # (e.g. the user detached and reattached a session to a new tab)
+        # take effect immediately. Building the closure is microsecond-cheap.
+        if payload.iterm_session_id:
             orchestrator.register_focuser(
                 agent_id, make_iterm_focuser(payload.iterm_session_id)
             )

--- a/src/deckhand/main.py
+++ b/src/deckhand/main.py
@@ -24,9 +24,11 @@ from starlette.responses import JSONResponse
 from deckhand.agents.claude_code import ClaudeCodeAgent
 from deckhand.agents.cursor import CursorAgent
 from deckhand.agents.mock import MockAgent
+from deckhand.agents.pending_input import PendingInputTracker
 from deckhand.agents.summary import update_cursor_summary
 from deckhand.config.settings import Settings
 from deckhand.event_log import EventLogger
+from deckhand.focusers.iterm import make_iterm_focuser
 from deckhand.logging_config import configure_logging
 from deckhand.metrics import Metrics
 from deckhand.orchestrator.actions import ActionRegistry
@@ -141,6 +143,11 @@ async def lifespan(app: FastAPI):
         event_logger = EventLogger(settings.event_log_path)
         orchestrator.event_bus.add_listener(event_logger)
         logger.info("Event log writing to %s", event_logger.path)
+
+    # Pending-input aggregator: maintains agents.pending_input{,_count}
+    # state from agent.status_changed / agent.unregistered events.
+    pending_tracker = PendingInputTracker(orchestrator.state_store)
+    orchestrator.event_bus.add_listener(pending_tracker)
 
     logger.info("Deckhand service started")
 
@@ -285,6 +292,7 @@ class ClaudeCodeHookPayload(BaseModel):
     hook_event_name: str
     cwd: str | None = None
     transcript_path: str | None = None
+    iterm_session_id: str | None = None
 
 
 class CursorHookPayload(BaseModel):
@@ -522,6 +530,10 @@ async def claude_code_hook(payload: ClaudeCodeHookPayload) -> dict[str, object]:
             project_root=payload.cwd,
         )
         orchestrator.register_agent(agent)
+        if payload.iterm_session_id:
+            orchestrator.register_focuser(
+                agent_id, make_iterm_focuser(payload.iterm_session_id)
+            )
         await orchestrator.event_bus.emit(
             build_event(
                 "agent.registered",
@@ -533,6 +545,12 @@ async def claude_code_hook(payload: ClaudeCodeHookPayload) -> dict[str, object]:
         agent = existing  # type: ignore[assignment]
         if payload.cwd and agent.project_root != payload.cwd:
             agent.project_root = payload.cwd
+        # Late-arriving iterm_session_id (e.g. user upgraded their hook
+        # script mid-session) — register the focuser if missing.
+        if payload.iterm_session_id and agent_id not in orchestrator.focusers:
+            orchestrator.register_focuser(
+                agent_id, make_iterm_focuser(payload.iterm_session_id)
+            )
 
     if not isinstance(agent, ClaudeCodeAgent):
         raise HTTPException(

--- a/src/deckhand/orchestrator/actions.py
+++ b/src/deckhand/orchestrator/actions.py
@@ -18,6 +18,8 @@ class OrchestratorActions(Protocol):
 
     def get_agent(self, agent_id: str) -> Any: ...
 
+    async def focus_next_pending(self) -> str | None: ...
+
 
 ActionHandler = Callable[[dict[str, object]], Awaitable[None]]
 
@@ -110,6 +112,9 @@ class ActionRegistry:
                 )
             )
 
+        async def focus_next_pending(payload: dict[str, object]) -> None:
+            await self._orchestrator.focus_next_pending()
+
         async def focus_cursor_agent(payload: dict[str, object]) -> None:
             agent_id = payload.get("agent_id")
             if not agent_id:
@@ -173,4 +178,13 @@ class ActionRegistry:
             focus_cursor_agent,
             description="Focus Cursor on an agent's project (macOS opens Cursor locally)",
             payload_schema={"agent_id": {"type": "string", "required": True}},
+        )
+        self.register(
+            "agents.focus_next_pending",
+            focus_next_pending,
+            description=(
+                "Focus the oldest agent currently awaiting input; no-op if the "
+                "pending list is empty or no focuser is registered."
+            ),
+            payload_schema={},
         )

--- a/src/deckhand/orchestrator/focusers.py
+++ b/src/deckhand/orchestrator/focusers.py
@@ -1,0 +1,40 @@
+"""Per-agent focuser registry.
+
+A focuser is an async callable that, when invoked, brings the agent's
+window/tab to the foreground on the local machine. Each agent type
+registers its own focuser when the agent registers (e.g. an iTerm focuser
+for a Claude Code session, an AppleScript focuser for Cursor in a future
+ticket). The registry stores them keyed by agent id and the
+``agents.focus_next_pending`` action looks them up at press time.
+
+Focusers are in-process state — after a Deckhand restart they re-register
+when the next hook fires from each session.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+Focuser = Callable[[], Awaitable[None]]
+
+
+class FocuserRegistry:
+    """Maps agent id → async focuser callable."""
+
+    def __init__(self) -> None:
+        self._focusers: dict[str, Focuser] = {}
+
+    def register(self, agent_id: str, focuser: Focuser) -> None:
+        self._focusers[agent_id] = focuser
+
+    def unregister(self, agent_id: str) -> None:
+        self._focusers.pop(agent_id, None)
+
+    def get(self, agent_id: str) -> Focuser | None:
+        return self._focusers.get(agent_id)
+
+    def __contains__(self, agent_id: str) -> bool:
+        return agent_id in self._focusers

--- a/src/deckhand/orchestrator/manager.py
+++ b/src/deckhand/orchestrator/manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Iterable
 
@@ -10,6 +11,12 @@ from deckhand.orchestrator.focusers import Focuser, FocuserRegistry
 from deckhand.orchestrator.state import StateStore
 
 logger = logging.getLogger(__name__)
+
+# Cap any single focuser invocation so a hung focuser cannot pin the
+# action handler indefinitely. Individual focusers may have their own
+# tighter timeout (the iTerm one caps osascript at 5s); this is the
+# safety net for any focuser that forgets.
+_FOCUSER_TIMEOUT_SEC = 10.0
 
 
 class Orchestrator:
@@ -85,7 +92,14 @@ class Orchestrator:
                 logger.info("pending agent %s has no focuser; skipping", agent_id)
                 continue
             try:
-                await focuser()
+                await asyncio.wait_for(focuser(), timeout=_FOCUSER_TIMEOUT_SEC)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "focuser for %s timed out after %.1fs",
+                    agent_id,
+                    _FOCUSER_TIMEOUT_SEC,
+                )
+                continue
             except Exception:
                 logger.exception("focuser for %s failed", agent_id)
                 continue

--- a/src/deckhand/orchestrator/manager.py
+++ b/src/deckhand/orchestrator/manager.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import logging
 from typing import Iterable
 
 from deckhand.agents.base import AgentBase
 from deckhand.metrics import Metrics
 from deckhand.orchestrator.events import EventBus
+from deckhand.orchestrator.focusers import Focuser, FocuserRegistry
 from deckhand.orchestrator.state import StateStore
+
+logger = logging.getLogger(__name__)
 
 
 class Orchestrator:
@@ -20,6 +24,7 @@ class Orchestrator:
         self.metrics = metrics
         self.event_bus = EventBus(metrics=metrics)
         self.state_store = StateStore(self.event_bus, persist_path=state_persist_path)
+        self.focusers = FocuserRegistry()
 
     def register_agent(self, agent: AgentBase) -> None:
         agent.on_event = self.event_bus.emit
@@ -29,7 +34,13 @@ class Orchestrator:
         agent = self.agents.pop(agent_id, None)
         if agent is not None:
             agent.on_event = None
+        # Focusers are tied to a specific live agent registration; drop on
+        # unregister so a re-registered session must re-supply its focuser.
+        self.focusers.unregister(agent_id)
         return agent
+
+    def register_focuser(self, agent_id: str, focuser: Focuser) -> None:
+        self.focusers.register(agent_id, focuser)
 
     def list_agents(self) -> Iterable[AgentBase]:
         return self.agents.values()
@@ -54,3 +65,29 @@ class Orchestrator:
         if agent is None:
             raise KeyError(agent_id)
         await agent.provide_input(text)
+
+    async def focus_next_pending(self) -> str | None:
+        """Focus the oldest agent in `awaiting_input` whose focuser is registered.
+
+        Reads ``agents.pending_input`` from the state store fresh on every
+        call — each press of a Stream Deck button thus targets the current
+        head of the queue, and resolved agents drop out naturally. Returns
+        the focused agent id, or ``None`` if there is no pending agent (or
+        none of the pending agents have a registered focuser).
+        """
+        pending_entry = self.state_store.get_state("agents.pending_input")
+        if not pending_entry:
+            return None
+        agent_ids = (pending_entry.get("value") or {}).get("agent_ids") or []
+        for agent_id in agent_ids:
+            focuser = self.focusers.get(agent_id)
+            if focuser is None:
+                logger.info("pending agent %s has no focuser; skipping", agent_id)
+                continue
+            try:
+                await focuser()
+            except Exception:
+                logger.exception("focuser for %s failed", agent_id)
+                continue
+            return agent_id
+        return None

--- a/tests/test_claude_code_hook_api.py
+++ b/tests/test_claude_code_hook_api.py
@@ -190,6 +190,50 @@ async def test_hook_late_registers_focuser_on_subsequent_event(
     assert "claude-code-1234dead" in main_mod.orchestrator.focusers
 
 
+async def test_hook_replaces_focuser_when_iterm_session_id_changes(
+    client: AsyncClient,
+) -> None:
+    """If the session reattaches to a new iTerm tab mid-session, rebind the focuser."""
+    import deckhand.main as main_mod
+
+    captured: list[str] = []
+
+    def fake_make_focuser(session_id: str):
+        captured.append(session_id)
+
+        async def f() -> None: ...
+
+        return f
+
+    main_mod.make_iterm_focuser = fake_make_focuser  # type: ignore[assignment]
+    try:
+        session_id = "abcabc00abcabc00"
+        await client.post(
+            "/agents/claude-code/hook",
+            json={
+                "session_id": session_id,
+                "hook_event_name": "SessionStart",
+                "cwd": "/tmp/p",
+                "iterm_session_id": "iterm-OLD",
+            },
+        )
+        await client.post(
+            "/agents/claude-code/hook",
+            json={
+                "session_id": session_id,
+                "hook_event_name": "UserPromptSubmit",
+                "cwd": "/tmp/p",
+                "iterm_session_id": "iterm-NEW",
+            },
+        )
+        # SessionStart bound OLD, UserPromptSubmit bound NEW (replace, not skip).
+        assert captured == ["iterm-OLD", "iterm-NEW"]
+    finally:
+        from deckhand.focusers import iterm as iterm_mod
+
+        main_mod.make_iterm_focuser = iterm_mod.make_iterm_focuser  # type: ignore[assignment]
+
+
 async def test_hook_session_end_drops_focuser(client: AsyncClient) -> None:
     import deckhand.main as main_mod
 
@@ -269,7 +313,7 @@ async def test_focus_next_pending_action_against_live_orchestrator(
         assert resp.status_code == 200
         assert calls == ["iterm-A", "iterm-B"]
 
-        # Empty queue: still success (action is no-op).
+        # Empty queue: still success (action is no-op) AND no focuser fires.
         await client.post(
             "/agents/claude-code/hook",
             json={
@@ -281,6 +325,9 @@ async def test_focus_next_pending_action_against_live_orchestrator(
         )
         resp = await client.post("/actions/agents.focus_next_pending", json={})
         assert resp.status_code == 200
+        # Guard against a regression that fires a stale focuser: calls
+        # must NOT have grown beyond the two real presses above.
+        assert calls == ["iterm-A", "iterm-B"]
     finally:
         # Restore so other tests in the module pick up the real symbol.
         main_mod.make_iterm_focuser = iterm_mod.make_iterm_focuser  # type: ignore[assignment]

--- a/tests/test_claude_code_hook_api.py
+++ b/tests/test_claude_code_hook_api.py
@@ -124,6 +124,168 @@ async def test_hook_distinct_sessions_yield_distinct_agents(
     assert "/tmp/beta" in roots
 
 
+async def test_hook_registers_iterm_focuser_when_session_id_present(
+    client: AsyncClient,
+) -> None:
+    """SessionStart with iterm_session_id binds a focuser on the orchestrator."""
+    import deckhand.main as main_mod
+
+    await client.post(
+        "/agents/claude-code/hook",
+        json={
+            "session_id": "feedface00000000",
+            "hook_event_name": "SessionStart",
+            "cwd": "/tmp/p",
+            "iterm_session_id": "iterm-uuid-xyz",
+        },
+    )
+    assert main_mod.orchestrator is not None
+    assert "claude-code-feedface" in main_mod.orchestrator.focusers
+
+
+async def test_hook_skips_focuser_when_iterm_session_id_absent(
+    client: AsyncClient,
+) -> None:
+    """Without iterm_session_id (e.g. Terminal.app), the agent is unfocusable."""
+    import deckhand.main as main_mod
+
+    await client.post(
+        "/agents/claude-code/hook",
+        json={
+            "session_id": "feedbeef00000000",
+            "hook_event_name": "SessionStart",
+            "cwd": "/tmp/p",
+        },
+    )
+    assert main_mod.orchestrator is not None
+    assert "claude-code-feedbeef" not in main_mod.orchestrator.focusers
+
+
+async def test_hook_late_registers_focuser_on_subsequent_event(
+    client: AsyncClient,
+) -> None:
+    """User upgrades their hook script mid-session; focuser binds late."""
+    import deckhand.main as main_mod
+
+    session_id = "1234deadbeef0000"
+    await client.post(
+        "/agents/claude-code/hook",
+        json={
+            "session_id": session_id,
+            "hook_event_name": "SessionStart",
+            "cwd": "/tmp/p",
+        },
+    )
+    assert "claude-code-1234dead" not in main_mod.orchestrator.focusers
+
+    await client.post(
+        "/agents/claude-code/hook",
+        json={
+            "session_id": session_id,
+            "hook_event_name": "UserPromptSubmit",
+            "cwd": "/tmp/p",
+            "iterm_session_id": "iterm-uuid-late",
+        },
+    )
+    assert "claude-code-1234dead" in main_mod.orchestrator.focusers
+
+
+async def test_hook_session_end_drops_focuser(client: AsyncClient) -> None:
+    import deckhand.main as main_mod
+
+    session_id = "f00dface00000000"
+    await client.post(
+        "/agents/claude-code/hook",
+        json={
+            "session_id": session_id,
+            "hook_event_name": "SessionStart",
+            "cwd": "/tmp/p",
+            "iterm_session_id": "iterm-uuid-bye",
+        },
+    )
+    assert "claude-code-f00dface" in main_mod.orchestrator.focusers
+
+    await client.post(
+        "/agents/claude-code/hook",
+        json={"session_id": session_id, "hook_event_name": "SessionEnd"},
+    )
+    assert "claude-code-f00dface" not in main_mod.orchestrator.focusers
+
+
+async def test_focus_next_pending_action_against_live_orchestrator(
+    client: AsyncClient,
+) -> None:
+    """Full integration: two awaiting agents → first press focuses head."""
+    import deckhand.main as main_mod
+    from deckhand.focusers import iterm as iterm_mod
+
+    calls: list[str] = []
+
+    def fake_make_focuser(session_id: str):
+        async def f() -> None:
+            calls.append(session_id)
+
+        return f
+
+    # Patch where the symbol is imported, not its source module.
+    main_mod.make_iterm_focuser = fake_make_focuser  # type: ignore[assignment]
+    try:
+        for letter, iterm_id in [("a", "iterm-A"), ("b", "iterm-B")]:
+            await client.post(
+                "/agents/claude-code/hook",
+                json={
+                    "session_id": f"{letter}" * 16,
+                    "hook_event_name": "SessionStart",
+                    "cwd": f"/tmp/{letter}",
+                    "iterm_session_id": iterm_id,
+                },
+            )
+            await client.post(
+                "/agents/claude-code/hook",
+                json={
+                    "session_id": f"{letter}" * 16,
+                    "hook_event_name": "Notification",
+                    "cwd": f"/tmp/{letter}",
+                    "iterm_session_id": iterm_id,
+                },
+            )
+
+        # State should reflect both pending; press the action and 'A' focuses.
+        resp = await client.post("/actions/agents.focus_next_pending", json={})
+        assert resp.status_code == 200
+        assert calls == ["iterm-A"]
+
+        # Agent A resolves; next press should focus B.
+        await client.post(
+            "/agents/claude-code/hook",
+            json={
+                "session_id": "a" * 16,
+                "hook_event_name": "Stop",
+                "cwd": "/tmp/a",
+                "iterm_session_id": "iterm-A",
+            },
+        )
+        resp = await client.post("/actions/agents.focus_next_pending", json={})
+        assert resp.status_code == 200
+        assert calls == ["iterm-A", "iterm-B"]
+
+        # Empty queue: still success (action is no-op).
+        await client.post(
+            "/agents/claude-code/hook",
+            json={
+                "session_id": "b" * 16,
+                "hook_event_name": "Stop",
+                "cwd": "/tmp/b",
+                "iterm_session_id": "iterm-B",
+            },
+        )
+        resp = await client.post("/actions/agents.focus_next_pending", json={})
+        assert resp.status_code == 200
+    finally:
+        # Restore so other tests in the module pick up the real symbol.
+        main_mod.make_iterm_focuser = iterm_mod.make_iterm_focuser  # type: ignore[assignment]
+
+
 async def test_hook_requires_auth() -> None:
     import importlib
     import deckhand.main as main_mod

--- a/tests/test_focusers.py
+++ b/tests/test_focusers.py
@@ -1,0 +1,188 @@
+"""Tests for the FocuserRegistry and the iTerm AppleScript focuser."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from deckhand.agents.mock import MockAgent
+from deckhand.focusers.iterm import _build_applescript, make_iterm_focuser
+from deckhand.orchestrator.focusers import FocuserRegistry
+from deckhand.orchestrator.manager import Orchestrator
+
+
+# --------------------------------------------------------- FocuserRegistry ---
+
+
+async def test_registry_register_and_get() -> None:
+    registry = FocuserRegistry()
+
+    async def f() -> None: ...
+
+    registry.register("agent-a", f)
+    assert registry.get("agent-a") is f
+    assert "agent-a" in registry
+
+
+async def test_registry_unregister_clears() -> None:
+    registry = FocuserRegistry()
+
+    async def f() -> None: ...
+
+    registry.register("agent-a", f)
+    registry.unregister("agent-a")
+    assert registry.get("agent-a") is None
+    assert "agent-a" not in registry
+
+
+async def test_registry_unregister_unknown_is_noop() -> None:
+    registry = FocuserRegistry()
+    registry.unregister("never-existed")  # must not raise
+
+
+# --------------------------------------------------------- Orchestrator wiring
+
+
+async def test_orchestrator_drops_focuser_when_agent_unregisters() -> None:
+    orch = Orchestrator()
+    agent = MockAgent(agent_id="mock-1")
+    orch.register_agent(agent)
+
+    called: list[bool] = []
+
+    async def focuser() -> None:
+        called.append(True)
+
+    orch.register_focuser("mock-1", focuser)
+    assert "mock-1" in orch.focusers
+
+    orch.unregister_agent("mock-1")
+    assert "mock-1" not in orch.focusers
+
+
+async def test_focus_next_pending_empty_is_noop() -> None:
+    orch = Orchestrator()
+    result = await orch.focus_next_pending()
+    assert result is None
+
+
+async def test_focus_next_pending_invokes_head_focuser() -> None:
+    orch = Orchestrator()
+    calls: list[str] = []
+
+    async def focuser_a() -> None:
+        calls.append("a")
+
+    async def focuser_b() -> None:
+        calls.append("b")
+
+    orch.register_focuser("agent-a", focuser_a)
+    orch.register_focuser("agent-b", focuser_b)
+    await orch.state_store.set_state(
+        "agents.pending_input",
+        {"agent_ids": ["agent-a", "agent-b"]},
+        source={"kind": "tracker", "id": "agents.pending_input"},
+    )
+
+    focused = await orch.focus_next_pending()
+    assert focused == "agent-a"
+    assert calls == ["a"]
+
+
+async def test_focus_next_pending_skips_missing_focuser() -> None:
+    """If head has no registered focuser, fall through to the next one."""
+    orch = Orchestrator()
+    calls: list[str] = []
+
+    async def focuser_b() -> None:
+        calls.append("b")
+
+    orch.register_focuser("agent-b", focuser_b)
+    await orch.state_store.set_state(
+        "agents.pending_input",
+        {"agent_ids": ["agent-a", "agent-b"]},
+        source={"kind": "tracker", "id": "agents.pending_input"},
+    )
+
+    focused = await orch.focus_next_pending()
+    assert focused == "agent-b"
+    assert calls == ["b"]
+
+
+async def test_focus_next_pending_continues_on_focuser_failure() -> None:
+    orch = Orchestrator()
+
+    async def bad() -> None:
+        raise RuntimeError("boom")
+
+    async def good() -> None:
+        return None
+
+    orch.register_focuser("agent-a", bad)
+    orch.register_focuser("agent-b", good)
+    await orch.state_store.set_state(
+        "agents.pending_input",
+        {"agent_ids": ["agent-a", "agent-b"]},
+        source={"kind": "tracker", "id": "agents.pending_input"},
+    )
+
+    focused = await orch.focus_next_pending()
+    assert focused == "agent-b"
+
+
+# ---------------------------------------------------------- iTerm focuser ----
+
+
+def test_applescript_contains_session_id() -> None:
+    script = _build_applescript("ABC-123-DEF")
+    assert "ABC-123-DEF" in script
+    assert 'tell application "iTerm2"' in script
+    assert "activate" in script
+
+
+def test_applescript_escapes_quotes_in_session_id() -> None:
+    """A pathological session id with a double-quote must not break the script."""
+    script = _build_applescript('abc"injected"')
+    # The raw quote should be backslash-escaped so AppleScript treats it as
+    # one literal string rather than ending the contains argument early.
+    assert 'abc\\"injected\\"' in script
+
+
+async def test_iterm_focuser_invokes_osascript() -> None:
+    focuser = make_iterm_focuser("uuid-1")
+
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", return_value=completed) as run:
+        await focuser()
+
+    assert run.call_count == 1
+    args, kwargs = run.call_args
+    cmd = args[0]
+    assert cmd[0] == "osascript"
+    assert cmd[1] == "-e"
+    assert "uuid-1" in cmd[2]
+    assert kwargs.get("timeout") == 5
+
+
+async def test_iterm_focuser_swallows_osascript_failure() -> None:
+    focuser = make_iterm_focuser("uuid-1")
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="something broke"
+    )
+    with patch("subprocess.run", return_value=completed):
+        await focuser()  # must not raise
+
+
+async def test_iterm_focuser_swallows_missing_osascript() -> None:
+    focuser = make_iterm_focuser("uuid-1")
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        await focuser()  # must not raise
+
+
+async def test_iterm_focuser_swallows_timeout() -> None:
+    focuser = make_iterm_focuser("uuid-1")
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="osascript", timeout=5),
+    ):
+        await focuser()  # must not raise

--- a/tests/test_focusers.py
+++ b/tests/test_focusers.py
@@ -148,6 +148,67 @@ def test_applescript_escapes_quotes_in_session_id() -> None:
     assert 'abc\\"injected\\"' in script
 
 
+def test_applescript_escapes_backslash_in_session_id() -> None:
+    """A trailing backslash must be escaped or it eats the closing quote."""
+    script = _build_applescript("abc\\")
+    # Backslash escape first → "abc\\" inside the script (two backslashes
+    # before the closing quote), not the raw single backslash.
+    assert "abc\\\\" in script
+
+
+def test_applescript_escapes_backslash_quote_combo() -> None:
+    """Backslash then quote must produce \\\\ \\\" (escape backslash first)."""
+    script = _build_applescript('a\\"b')
+    # In the literal we expect: backslash-backslash then backslash-quote,
+    # i.e. four characters: \ \ \ ".
+    assert 'a\\\\\\"b' in script
+
+
+def test_applescript_strips_newlines_and_control_chars() -> None:
+    """Control characters get dropped so they can't break out of the literal."""
+    script = _build_applescript("abc\ndef\rghi\x00jkl")
+    assert "abcdefghijkl" in script
+    # The literal newline must not appear inside the quoted contains arg.
+    quoted = script.split('contains "', 1)[1].split('"', 1)[0]
+    assert "\n" not in quoted
+    assert "\r" not in quoted
+    assert "\x00" not in quoted
+
+
+# ----------------------------------------------------- focuser timeout ----
+
+
+async def test_focus_next_pending_times_out_hung_focuser() -> None:
+    """A focuser that hangs must not pin the action handler forever."""
+    import asyncio as _asyncio
+
+    from deckhand.orchestrator import manager as manager_mod
+
+    orch = Orchestrator()
+    fired: list[str] = []
+
+    async def hung() -> None:
+        await _asyncio.sleep(60)  # would block; will be cancelled
+
+    async def quick() -> None:
+        fired.append("quick")
+
+    orch.register_focuser("agent-a", hung)
+    orch.register_focuser("agent-b", quick)
+    await orch.state_store.set_state(
+        "agents.pending_input",
+        {"agent_ids": ["agent-a", "agent-b"]},
+        source={"kind": "tracker", "id": "agents.pending_input"},
+    )
+
+    # Shrink the timeout for the test so we don't actually wait 10s.
+    with patch.object(manager_mod, "_FOCUSER_TIMEOUT_SEC", 0.05):
+        focused = await orch.focus_next_pending()
+
+    assert focused == "agent-b"
+    assert fired == ["quick"]
+
+
 async def test_iterm_focuser_invokes_osascript() -> None:
     focuser = make_iterm_focuser("uuid-1")
 

--- a/tests/test_pending_input.py
+++ b/tests/test_pending_input.py
@@ -1,0 +1,146 @@
+"""Tests for the PendingInputTracker derived-state aggregator."""
+
+from __future__ import annotations
+
+import pytest
+
+from deckhand.agents.base import AgentStatus
+from deckhand.agents.mock import MockAgent
+from deckhand.agents.pending_input import PendingInputTracker
+from deckhand.orchestrator.events import EventBus, build_event
+from deckhand.orchestrator.state import StateStore
+
+
+@pytest.fixture
+def bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def store(bus: EventBus) -> StateStore:
+    return StateStore(bus)
+
+
+@pytest.fixture
+def tracker(bus: EventBus, store: StateStore) -> PendingInputTracker:
+    t = PendingInputTracker(store)
+    bus.add_listener(t)
+    return t
+
+
+def _status_event(agent_id: str, status: str) -> dict:
+    return build_event(
+        "agent.status_changed",
+        {"kind": "agent", "id": agent_id},
+        {"agent": {"id": agent_id, "status": status}},
+    )
+
+
+def _unregistered_event(agent_id: str) -> dict:
+    return build_event(
+        "agent.unregistered",
+        {"kind": "agent", "id": agent_id},
+        {"agent_id": agent_id, "reason": "session_end"},
+    )
+
+
+async def test_initial_state_empty(
+    tracker: PendingInputTracker, store: StateStore
+) -> None:
+    assert store.get_state(tracker.STATE_LIST_KEY) is None
+    assert store.get_state(tracker.STATE_COUNT_KEY) is None
+    assert tracker.pending_ids == []
+
+
+async def test_single_agent_awaiting_appears_in_state(
+    bus: EventBus, tracker: PendingInputTracker, store: StateStore
+) -> None:
+    await bus.emit(_status_event("claude-code-aaa", "awaiting_input"))
+
+    entry = store.get_state(tracker.STATE_LIST_KEY)
+    assert entry is not None
+    assert entry["value"] == {"agent_ids": ["claude-code-aaa"]}
+
+    count_entry = store.get_state(tracker.STATE_COUNT_KEY)
+    assert count_entry is not None
+    assert count_entry["value"] == {"count": 1}
+
+
+async def test_insertion_order_preserved_oldest_first(
+    bus: EventBus, tracker: PendingInputTracker, store: StateStore
+) -> None:
+    await bus.emit(_status_event("agent-a", "awaiting_input"))
+    await bus.emit(_status_event("agent-b", "awaiting_input"))
+    await bus.emit(_status_event("agent-c", "awaiting_input"))
+
+    entry = store.get_state(tracker.STATE_LIST_KEY)
+    assert entry["value"]["agent_ids"] == ["agent-a", "agent-b", "agent-c"]
+    assert tracker.pending_ids == ["agent-a", "agent-b", "agent-c"]
+
+
+async def test_status_transition_away_removes_agent(
+    bus: EventBus, tracker: PendingInputTracker, store: StateStore
+) -> None:
+    await bus.emit(_status_event("agent-a", "awaiting_input"))
+    await bus.emit(_status_event("agent-b", "awaiting_input"))
+    await bus.emit(_status_event("agent-a", "running"))
+
+    entry = store.get_state(tracker.STATE_LIST_KEY)
+    assert entry["value"]["agent_ids"] == ["agent-b"]
+    assert store.get_state(tracker.STATE_COUNT_KEY)["value"] == {"count": 1}
+
+
+async def test_double_awaiting_does_not_duplicate(
+    bus: EventBus, tracker: PendingInputTracker, store: StateStore
+) -> None:
+    await bus.emit(_status_event("agent-a", "awaiting_input"))
+    await bus.emit(_status_event("agent-a", "awaiting_input"))
+
+    assert tracker.pending_ids == ["agent-a"]
+    assert store.get_state(tracker.STATE_COUNT_KEY)["value"] == {"count": 1}
+
+
+async def test_unregistration_drops_pending_agent(
+    bus: EventBus, tracker: PendingInputTracker, store: StateStore
+) -> None:
+    await bus.emit(_status_event("agent-a", "awaiting_input"))
+    await bus.emit(_status_event("agent-b", "awaiting_input"))
+    await bus.emit(_unregistered_event("agent-a"))
+
+    assert tracker.pending_ids == ["agent-b"]
+    assert store.get_state(tracker.STATE_LIST_KEY)["value"] == {
+        "agent_ids": ["agent-b"]
+    }
+
+
+async def test_unregister_of_unknown_agent_is_noop(
+    bus: EventBus, tracker: PendingInputTracker, store: StateStore
+) -> None:
+    await bus.emit(_status_event("agent-a", "awaiting_input"))
+    await bus.emit(_unregistered_event("agent-zzz-unknown"))
+
+    assert tracker.pending_ids == ["agent-a"]
+
+
+async def test_mid_cycle_resolution_keeps_remaining_pending(
+    bus: EventBus, tracker: PendingInputTracker
+) -> None:
+    """Acceptance scenario: agent resolves while another is still pending."""
+    await bus.emit(_status_event("agent-a", "awaiting_input"))
+    await bus.emit(_status_event("agent-b", "awaiting_input"))
+    # 'agent-a' resolves before we focus it (e.g. user typed in the terminal).
+    await bus.emit(_status_event("agent-a", "idle"))
+    # Now head should be 'agent-b'.
+    assert tracker.pending_ids == ["agent-b"]
+
+
+async def test_drives_off_real_agent_status_changes(
+    bus: EventBus, tracker: PendingInputTracker, store: StateStore
+) -> None:
+    """Whole-bus integration: a real AgentBase emits via bus → tracker reacts."""
+    agent = MockAgent(agent_id="mock-input")
+    agent.on_event = bus.emit
+    await agent._set_status(AgentStatus.AWAITING_INPUT)
+    assert tracker.pending_ids == ["mock-input"]
+    await agent._set_status(AgentStatus.IDLE)
+    assert tracker.pending_ids == []


### PR DESCRIPTION
The headline feature for v0.3: one Stream Deck button that shows how many Claude Code sessions are waiting for input, and on each press jumps iTerm to whichever session is at the head of the queue.

## What this PR adds

**Aggregator.** A new `PendingInputTracker` subscribes to the event bus and maintains two derived state keys whenever an agent enters/leaves `awaiting_input` or is unregistered:

- `agents.pending_input` → `{"agent_ids": [...]}` (oldest pending first)
- `agents.pending_input_count` → `{"count": N}` (separate key so a Data Widget button can bind a simple numeric formatter without parsing the list)

**Focuser registry.** Per-agent_id async callable on the orchestrator. Bound when an agent registers, cleared automatically on `unregister_agent` — so a re-registered session must re-supply its focuser. This is what makes restart safe: focusers re-bind when the next hook fires from each session.

**iTerm focuser** — `osascript` AppleScript. Decision documented at #23:

- No dependency on the user enabling iTerm's Python runtime.
- Zero new Python deps (`osascript` ships with macOS).
- iTerm's AppleScript surface is stable; per-session UUIDs match via `id of <session>`.
- Easier to mock in tests (one `subprocess.run` call).

Failures (missing `osascript`, timeout, non-zero exit, exception) log and swallow so a flaky focuser cannot crash the bus.

**Hook payload extension.** `ClaudeCodeHookPayload` gains optional `iterm_session_id`. When present on first sighting (or on a subsequent event if missing earlier), an iTerm focuser is bound for the agent. Absent → agent tracks normally, just isn't focusable. No wrapper script needed.

**Example hooks updated.** `examples/claude_code_hooks.json` now wraps every hook command with `jq -c '. + {iterm_session_id: env.ITERM_SESSION_ID}'`. iTerm sets `$ITERM_SESSION_ID` automatically in every shell; outside iTerm the field is null and the agent is just non-focusable. Users redeploy their `~/.claude/settings.json` hooks block to opt in.

**New default action `agents.focus_next_pending`** (no payload). Reads the pending list fresh on every press, walks down the list invoking the first agent with a working focuser, returns the focused id (or `None` if empty / nothing worked). Each press is independent, so mid-cycle resolution naturally drops resolved agents.

## Scope

In: iTerm focuser, Claude Code adapter, pending-input aggregator, action.
Out (per ticket): Cursor focus (#24), browser focus (#25), cross-machine.

## v1 constraints (documented in code + ticket)

- **iTerm only.** Outside iTerm, no `$ITERM_SESSION_ID` → no focuser → agent shows up in the queue but `focus_next_pending` skips it.
- **Restart re-binds.** Focusers live in process memory. After a Deckhand restart they re-register from the next hook each session fires. Pending-input state rebuilds from agent status changes after the first relevant event.
- **AppleScript matching is `contains`** on the UUID so iTerm's longer `w0t1p0:UUID` form still matches the raw UUID we capture.

## Test plan

- 28 new tests across `test_pending_input.py`, `test_focusers.py`, and `test_claude_code_hook_api.py` cover:
  - Aggregator ordering (oldest first), double-awaiting (no duplicates), transitions away, unregistration, mid-cycle resolution, integration with real `AgentBase` emits.
  - Focuser registry CRUD; orchestrator dropping focuser on agent unregister.
  - `focus_next_pending`: empty (no-op success), head invocation, skip-missing, continue-past-failure.
  - iTerm AppleScript: UUID injection, quote escaping; subprocess success / non-zero / `FileNotFoundError` / `TimeoutExpired` all swallow.
  - Hook API: focuser registered when `iterm_session_id` present, skipped when absent, late-bound on a subsequent event, dropped on `SessionEnd`.
  - Full HTTP cycle: two awaiting agents → first press focuses A, second focuses B, third on empty queue still returns 200.
- `make check` clean: ruff lint, ruff format, **170 tests passing** (up from 142).

Closes #23
