### PR TITLE
Add claude_code_usage plugin: token totals from JSONL session logs

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -12,8 +12,26 @@ port = 8000
 # List of plugin module paths to load
 modules = [
   "deckhand.plugins.builtin",
+  # "deckhand.plugins.claude_code_usage",
   # "my_custom_plugin",
 ]
+
+# Per-plugin configuration: read by the plugin's own register() function.
+#
+# [plugins.claude_code_usage]
+# Polls Claude Code session logs (~/.claude/projects/**/*.jsonl) and writes
+# three state keys for Data Widget buttons: usage.claude_code.session_tokens,
+# .week_tokens, .week_sonnet_tokens. Each entry has shape:
+#   { label, current, max, percent, unit, updated_at }
+# `max` and `percent` are null unless you configure the *_token_cap below —
+# Anthropic's per-session/weekly caps are not exposed on disk.
+#
+# poll_interval_seconds = 30
+# session_window_hours  = 5
+# data_dir              = "~/.claude"
+# session_token_cap     = 500000
+# week_token_cap        = 10000000
+# week_sonnet_token_cap = 5000000
 
 [paths]
 # Path to JSON file for persisting state across restarts (optional)

--- a/src/deckhand/plugins/claude_code_usage.py
+++ b/src/deckhand/plugins/claude_code_usage.py
@@ -1,0 +1,341 @@
+"""Built-in plugin: derive Claude Code usage metrics from local session logs.
+
+Claude Code records every assistant message to a per-session JSONL file under
+``~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl``. Each assistant
+record carries ``message.usage`` (``input_tokens``, ``cache_creation_input_tokens``,
+``cache_read_input_tokens``, ``output_tokens``), ``message.model``, and a top-
+level ``timestamp``. This plugin polls those files and writes three normalized
+metrics to the state store so a Data Widget button can display them.
+
+What we found in the on-disk data:
+
+* ``~/.claude/stats-cache.json`` is daily message / session / tool-call counts
+  only — no token data, no caps. Not useful here.
+* The JSONL session logs are the only place authoritative token counts live.
+* **No cap information is anywhere on disk.** Claude's UI shows percentages
+  because Anthropic's server tells it the cap. So ``percent`` and ``max`` in
+  the published state are ``null`` unless the user configures expected caps
+  in ``[plugins.claude_code_usage]``.
+
+Heuristics (intentionally documented so a future maintainer can revisit):
+
+* **Token counting:** ``input_tokens + cache_creation_input_tokens +
+  output_tokens``. ``cache_read_input_tokens`` is excluded because cache
+  reads are not billed at full rate.
+* **Session window:** a rolling N hours from now (default 5). This is an
+  approximation of Claude's own session concept. It agrees with ``/usage``
+  during active use; it will diverge if you've been idle.
+* **Week window:** the last 7 calendar days, not "this calendar week" —
+  simpler, matches the rolling-window pattern, and lines up better with
+  Anthropic's Sonnet weekly cap which also rolls.
+* **Sonnet filter:** case-insensitive ``"sonnet" in model_id``. Catches
+  ``claude-sonnet-4-6``, ``claude-3-5-sonnet``, etc.
+
+Configuration block (all keys optional)::
+
+    [plugins.claude_code_usage]
+    poll_interval_seconds = 30
+    session_window_hours  = 5
+    data_dir              = "~/.claude"
+    session_token_cap     = 500000
+    week_token_cap        = 10000000
+    week_sonnet_token_cap = 5000000
+
+Known limitation: the polling task is spawned at ``register()`` time and is
+never cancelled. On plugin reload it leaks until the service exits. This is
+intentional for v1 and will be cleaned up alongside the broader plugin
+shutdown hook tracked in #29.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from deckhand.config.loader import load_config
+from deckhand.plugins.registry import PluginRegistry
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_POLL_INTERVAL_SEC = 30.0
+_DEFAULT_SESSION_WINDOW_HOURS = 5.0
+_DEFAULT_DATA_DIR = "~/.claude"
+_WEEK_SECONDS = 7 * 24 * 3600
+_SOURCE = {"kind": "plugin", "id": "claude_code_usage"}
+
+
+def register(registry: PluginRegistry) -> None:
+    """Plugin entry point. Reads its own config and starts the poller."""
+    config = _load_plugin_config()
+
+    poll_interval = float(
+        config.get("poll_interval_seconds", _DEFAULT_POLL_INTERVAL_SEC)
+    )
+    session_window_hours = float(
+        config.get("session_window_hours", _DEFAULT_SESSION_WINDOW_HOURS)
+    )
+    data_dir = Path(str(config.get("data_dir", _DEFAULT_DATA_DIR))).expanduser()
+
+    caps = {
+        "session_tokens": _optional_int(config.get("session_token_cap")),
+        "week_tokens": _optional_int(config.get("week_token_cap")),
+        "week_sonnet_tokens": _optional_int(config.get("week_sonnet_token_cap")),
+    }
+
+    poller = UsagePoller(
+        registry=registry,
+        data_dir=data_dir,
+        poll_interval=poll_interval,
+        session_window_hours=session_window_hours,
+        caps=caps,
+    )
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # Plugin loaded outside a running loop (e.g. test setup). The caller
+        # is responsible for invoking ``poller.poll_once()`` directly.
+        logger.debug("no running loop; claude_code_usage poller not scheduled")
+        return
+
+    asyncio.create_task(poller.run())
+
+
+# ---------------------------------------------------------------- poller --
+
+
+class UsagePoller:
+    """Periodically scans Claude Code session logs and publishes usage state."""
+
+    METRIC_SESSION = "session_tokens"
+    METRIC_WEEK = "week_tokens"
+    METRIC_WEEK_SONNET = "week_sonnet_tokens"
+
+    def __init__(
+        self,
+        registry: PluginRegistry,
+        data_dir: Path,
+        poll_interval: float,
+        session_window_hours: float,
+        caps: dict[str, int | None],
+    ) -> None:
+        self._registry = registry
+        self._data_dir = data_dir
+        self._poll_interval = max(1.0, poll_interval)
+        self._session_window_sec = max(60.0, session_window_hours * 3600.0)
+        self._caps = caps
+
+    async def run(self) -> None:
+        while True:
+            try:
+                await self.poll_once()
+            except Exception:
+                logger.exception("claude_code_usage poll failed")
+            await asyncio.sleep(self._poll_interval)
+
+    async def poll_once(self) -> None:
+        now = time.time()
+        session_cutoff = now - self._session_window_sec
+        week_cutoff = now - _WEEK_SECONDS
+
+        session_tokens = 0
+        week_tokens = 0
+        week_sonnet_tokens = 0
+
+        for record in _iter_usage_records(self._data_dir, week_cutoff):
+            ts = record.timestamp
+            tokens = record.tokens
+            if ts >= week_cutoff:
+                week_tokens += tokens
+                if _is_sonnet(record.model):
+                    week_sonnet_tokens += tokens
+            if ts >= session_cutoff:
+                session_tokens += tokens
+
+        updated_at = now
+        await self._publish(
+            self.METRIC_SESSION,
+            label="Session tokens (rolling)",
+            current=session_tokens,
+            updated_at=updated_at,
+        )
+        await self._publish(
+            self.METRIC_WEEK,
+            label="Tokens (7d)",
+            current=week_tokens,
+            updated_at=updated_at,
+        )
+        await self._publish(
+            self.METRIC_WEEK_SONNET,
+            label="Sonnet tokens (7d)",
+            current=week_sonnet_tokens,
+            updated_at=updated_at,
+        )
+
+    async def _publish(
+        self, metric_id: str, *, label: str, current: int, updated_at: float
+    ) -> None:
+        cap = self._caps.get(metric_id)
+        percent = (current / cap * 100.0) if (cap and cap > 0) else None
+        value = {
+            "label": label,
+            "current": current,
+            "max": cap,
+            "percent": percent,
+            "unit": "tokens",
+            "updated_at": updated_at,
+        }
+        await self._registry.state.set_state(
+            f"usage.claude_code.{metric_id}",
+            value,
+            source=_SOURCE,
+        )
+
+
+# ---------------------------------------------------------------- parsing --
+
+
+class _UsageRecord:
+    """Lightweight value type for a single (timestamp, model, tokens) row."""
+
+    __slots__ = ("timestamp", "model", "tokens")
+
+    def __init__(self, timestamp: float, model: str, tokens: int) -> None:
+        self.timestamp = timestamp
+        self.model = model
+        self.tokens = tokens
+
+
+def _iter_usage_records(data_dir: Path, week_cutoff: float) -> Iterable[_UsageRecord]:
+    """Walk session JSONL files and yield one record per assistant message.
+
+    Files whose mtime is older than the week cutoff are skipped entirely;
+    we never need older data for any of the published metrics. Within a
+    file we parse line by line and skip anything that isn't a usage-bearing
+    assistant record.
+    """
+    projects_dir = data_dir / "projects"
+    if not projects_dir.is_dir():
+        return
+
+    for path in projects_dir.rglob("*.jsonl"):
+        try:
+            if path.stat().st_mtime < week_cutoff:
+                continue
+        except OSError:
+            continue
+        yield from _iter_file(path)
+
+
+def _iter_file(path: Path) -> Iterable[_UsageRecord]:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line_no, raw in enumerate(fh, 1):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    record = _parse_line(raw)
+                except (json.JSONDecodeError, ValueError, TypeError) as exc:
+                    logger.debug(
+                        "skipping malformed line %d in %s: %s", line_no, path, exc
+                    )
+                    continue
+                if record is not None:
+                    yield record
+    except OSError as exc:
+        logger.debug("could not read %s: %s", path, exc)
+
+
+def _parse_line(raw: str) -> _UsageRecord | None:
+    obj = json.loads(raw)
+    if not isinstance(obj, dict):
+        return None
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    model = str(message.get("model") or "")
+    tokens = _token_total(usage)
+    if tokens <= 0:
+        return None
+
+    ts = _parse_timestamp(obj.get("timestamp"))
+    if ts is None:
+        return None
+
+    return _UsageRecord(timestamp=ts, model=model, tokens=tokens)
+
+
+def _token_total(usage: dict[str, Any]) -> int:
+    # Heuristic: input + cache_creation + output. cache_read is excluded
+    # because cache reads are not billed at full rate.
+    def _int(key: str) -> int:
+        try:
+            return int(usage.get(key) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    return (
+        _int("input_tokens")
+        + _int("cache_creation_input_tokens")
+        + _int("output_tokens")
+    )
+
+
+def _parse_timestamp(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    try:
+        # Python's fromisoformat in 3.11+ accepts the trailing 'Z' suffix
+        # via replace, the explicit conversion below keeps it portable.
+        normalized = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except ValueError:
+        return None
+
+
+def _is_sonnet(model: str) -> bool:
+    return "sonnet" in model.lower()
+
+
+# ------------------------------------------------------------- config ----
+
+
+def _load_plugin_config() -> dict[str, Any]:
+    """Read the plugin's own ``[plugins.claude_code_usage]`` block from config.toml."""
+    config_file = os.getenv("DECKHAND_CONFIG_FILE")
+    if not config_file and Path("config.toml").exists():
+        config_file = "config.toml"
+    if not config_file:
+        return {}
+    full = load_config(config_file)
+    plugins = full.get("plugins", {})
+    section = plugins.get("claude_code_usage", {}) if isinstance(plugins, dict) else {}
+    return section if isinstance(section, dict) else {}
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    return n if n > 0 else None

--- a/src/deckhand/plugins/claude_code_usage.py
+++ b/src/deckhand/plugins/claude_code_usage.py
@@ -65,9 +65,16 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_POLL_INTERVAL_SEC = 30.0
 _DEFAULT_SESSION_WINDOW_HOURS = 5.0
+_MIN_POLL_INTERVAL_SEC = 1.0
+_MIN_SESSION_WINDOW_SEC = 60.0
 _DEFAULT_DATA_DIR = "~/.claude"
 _WEEK_SECONDS = 7 * 24 * 3600
 _SOURCE = {"kind": "plugin", "id": "claude_code_usage"}
+
+# Hold a strong reference to every scheduled poller task. asyncio.create_task
+# only keeps a weak reference, so without this the task can be garbage-
+# collected mid-run. Tasks self-deregister on completion.
+_BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
 
 
 def register(registry: PluginRegistry) -> None:
@@ -104,7 +111,9 @@ def register(registry: PluginRegistry) -> None:
         logger.debug("no running loop; claude_code_usage poller not scheduled")
         return
 
-    asyncio.create_task(poller.run())
+    task = asyncio.create_task(poller.run())
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
 
 
 # ---------------------------------------------------------------- poller --
@@ -127,9 +136,40 @@ class UsagePoller:
     ) -> None:
         self._registry = registry
         self._data_dir = data_dir
-        self._poll_interval = max(1.0, poll_interval)
-        self._session_window_sec = max(60.0, session_window_hours * 3600.0)
+        self._poll_interval = self._clamp(
+            "poll_interval_seconds",
+            poll_interval,
+            minimum=_MIN_POLL_INTERVAL_SEC,
+        )
+        session_window_sec = session_window_hours * 3600.0
+        clamped_sec = self._clamp(
+            "session_window_hours (seconds)",
+            session_window_sec,
+            minimum=_MIN_SESSION_WINDOW_SEC,
+        )
+        self._session_window_sec = clamped_sec
         self._caps = caps
+
+    @staticmethod
+    def _clamp(name: str, value: float, *, minimum: float) -> float:
+        """Floor ``value`` at ``minimum`` and log a warning when clamping fires.
+
+        Silent clamping hides configuration mistakes (a typo like
+        ``poll_interval_seconds = 0.5`` becomes a noisy floor instead of
+        a quiet override). The clamp itself prevents pathological values
+        from melting the disk; the warning surfaces the mistake to the
+        operator.
+        """
+        if value < minimum:
+            logger.warning(
+                "claude_code_usage: %s=%s is below minimum %s; using %s instead",
+                name,
+                value,
+                minimum,
+                minimum,
+            )
+            return minimum
+        return value
 
     async def run(self) -> None:
         while True:
@@ -278,17 +318,21 @@ def _parse_line(raw: str) -> _UsageRecord | None:
 
 def _token_total(usage: dict[str, Any]) -> int:
     # Heuristic: input + cache_creation + output. cache_read is excluded
-    # because cache reads are not billed at full rate.
-    def _int(key: str) -> int:
+    # because cache reads are not billed at full rate. Each component is
+    # floored at zero so a single negative field can't subtract from the
+    # running session/week sums (the outer ``tokens <= 0`` guard only
+    # checks the final total, which would let -10 + 20 = 10 sneak in).
+    def _nonneg_int(key: str) -> int:
         try:
-            return int(usage.get(key) or 0)
+            n = int(usage.get(key) or 0)
         except (TypeError, ValueError):
             return 0
+        return n if n > 0 else 0
 
     return (
-        _int("input_tokens")
-        + _int("cache_creation_input_tokens")
-        + _int("output_tokens")
+        _nonneg_int("input_tokens")
+        + _nonneg_int("cache_creation_input_tokens")
+        + _nonneg_int("output_tokens")
     )
 
 

--- a/tests/test_claude_code_usage.py
+++ b/tests/test_claude_code_usage.py
@@ -1,0 +1,380 @@
+"""Tests for the deckhand.plugins.claude_code_usage built-in plugin."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from deckhand.orchestrator.events import EventBus
+from deckhand.orchestrator.state import StateStore
+from deckhand.plugins import claude_code_usage as ccu
+
+
+# ----------------------------------------------------- fixtures + helpers ---
+
+
+@pytest.fixture
+def state() -> StateStore:
+    return StateStore(EventBus())
+
+
+def _registry_stub(state: StateStore):
+    class _StubRegistry:
+        pass
+
+    r = _StubRegistry()
+    r.state = state
+    return r
+
+
+def _record(
+    *,
+    timestamp: datetime,
+    model: str,
+    input_tokens: int = 0,
+    cache_creation: int = 0,
+    cache_read: int = 0,
+    output: int = 0,
+) -> dict[str, Any]:
+    return {
+        "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
+        "message": {
+            "model": model,
+            "role": "assistant",
+            "usage": {
+                "input_tokens": input_tokens,
+                "cache_creation_input_tokens": cache_creation,
+                "cache_read_input_tokens": cache_read,
+                "output_tokens": output,
+            },
+        },
+    }
+
+
+def _write_session(path: Path, *records: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+
+
+def _seed(data_dir: Path, *records: dict[str, Any], project: str = "p") -> None:
+    path = data_dir / "projects" / project / "session.jsonl"
+    _write_session(path, *records)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def _run_poll(state: StateStore, data_dir: Path, **kwargs) -> ccu.UsagePoller:
+    caps = kwargs.pop("caps", None) or {
+        "session_tokens": None,
+        "week_tokens": None,
+        "week_sonnet_tokens": None,
+    }
+    poller = ccu.UsagePoller(
+        registry=_registry_stub(state),
+        data_dir=data_dir,
+        poll_interval=kwargs.pop("poll_interval", 30.0),
+        session_window_hours=kwargs.pop("session_window_hours", 5.0),
+        caps=caps,
+    )
+    await poller.poll_once()
+    return poller
+
+
+# ----------------------------------------------------- happy-path metrics --
+
+
+async def test_publishes_three_metric_keys(state: StateStore, tmp_path: Path) -> None:
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(minutes=10),
+            model="claude-opus-4-7",
+            input_tokens=100,
+            output=200,
+        ),
+    )
+    await _run_poll(state, tmp_path)
+
+    keys = {entry["key"] for entry in state.list_state()}
+    assert "usage.claude_code.session_tokens" in keys
+    assert "usage.claude_code.week_tokens" in keys
+    assert "usage.claude_code.week_sonnet_tokens" in keys
+
+
+async def test_state_value_shape(state: StateStore, tmp_path: Path) -> None:
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(minutes=5),
+            model="claude-opus-4-7",
+            input_tokens=10,
+            output=20,
+        ),
+    )
+    await _run_poll(state, tmp_path)
+    entry = state.get_state("usage.claude_code.session_tokens")
+    value = entry["value"]
+    assert set(value.keys()) == {
+        "label",
+        "current",
+        "max",
+        "percent",
+        "unit",
+        "updated_at",
+    }
+    assert value["unit"] == "tokens"
+    assert value["max"] is None
+    assert value["percent"] is None
+    assert value["current"] == 30
+
+
+# --------------------------------------------------------- token counting --
+
+
+async def test_token_total_excludes_cache_read(
+    state: StateStore, tmp_path: Path
+) -> None:
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(minutes=5),
+            model="claude-opus-4-7",
+            input_tokens=10,
+            cache_creation=20,
+            cache_read=9999,  # must NOT be counted
+            output=30,
+        ),
+    )
+    await _run_poll(state, tmp_path)
+    entry = state.get_state("usage.claude_code.session_tokens")
+    assert entry["value"]["current"] == 60  # 10 + 20 + 30
+
+
+async def test_skips_records_without_usage(state: StateStore, tmp_path: Path) -> None:
+    """User messages and file-history-snapshot records carry no usage."""
+    records = [
+        {"type": "file-history-snapshot", "timestamp": _now().isoformat()},
+        {
+            "timestamp": _now().isoformat(),
+            "message": {"role": "user", "content": "hi"},
+        },
+        _record(
+            timestamp=_now() - timedelta(minutes=5),
+            model="claude-opus-4-7",
+            output=50,
+        ),
+    ]
+    _seed(tmp_path, *records)
+    await _run_poll(state, tmp_path)
+    assert state.get_state("usage.claude_code.session_tokens")["value"]["current"] == 50
+
+
+async def test_skips_malformed_lines(state: StateStore, tmp_path: Path) -> None:
+    """Garbage JSON lines must not abort the parse."""
+    path = tmp_path / "projects" / "p" / "session.jsonl"
+    path.parent.mkdir(parents=True)
+    good = _record(
+        timestamp=_now() - timedelta(minutes=1),
+        model="claude-opus-4-7",
+        output=42,
+    )
+    with path.open("w") as fh:
+        fh.write("{not json\n")
+        fh.write("\n")
+        fh.write(json.dumps(good) + "\n")
+        fh.write("null\n")
+    await _run_poll(state, tmp_path)
+    assert state.get_state("usage.claude_code.session_tokens")["value"]["current"] == 42
+
+
+# -------------------------------------------------------------- windows ----
+
+
+async def test_session_window_excludes_older_records(
+    state: StateStore, tmp_path: Path
+) -> None:
+    """A record older than session_window_hours appears in week_tokens but not session_tokens."""
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(hours=10),  # outside 5h session
+            model="claude-opus-4-7",
+            output=100,
+        ),
+        _record(
+            timestamp=_now() - timedelta(minutes=30),  # inside 5h
+            model="claude-opus-4-7",
+            output=50,
+        ),
+    )
+    await _run_poll(state, tmp_path)
+    assert state.get_state("usage.claude_code.session_tokens")["value"]["current"] == 50
+    assert state.get_state("usage.claude_code.week_tokens")["value"]["current"] == 150
+
+
+async def test_week_window_excludes_older_files(
+    state: StateStore, tmp_path: Path
+) -> None:
+    """A session log whose mtime is >7d old is skipped entirely (perf)."""
+    old_session = tmp_path / "projects" / "old" / "session.jsonl"
+    _write_session(
+        old_session,
+        _record(
+            timestamp=_now() - timedelta(days=20),
+            model="claude-opus-4-7",
+            output=9999,
+        ),
+    )
+    # Force mtime well outside the 7d window.
+    twenty_days_ago = time.time() - 20 * 86400
+    import os as _os
+
+    _os.utime(old_session, (twenty_days_ago, twenty_days_ago))
+
+    recent = tmp_path / "projects" / "recent" / "session.jsonl"
+    _write_session(
+        recent,
+        _record(
+            timestamp=_now() - timedelta(hours=1),
+            model="claude-opus-4-7",
+            output=7,
+        ),
+    )
+
+    await _run_poll(state, tmp_path)
+    assert state.get_state("usage.claude_code.week_tokens")["value"]["current"] == 7
+
+
+# --------------------------------------------------------------- Sonnet ----
+
+
+async def test_sonnet_filter_isolates_sonnet_models(
+    state: StateStore, tmp_path: Path
+) -> None:
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(minutes=1),
+            model="claude-opus-4-7",
+            output=1000,
+        ),
+        _record(
+            timestamp=_now() - timedelta(minutes=2),
+            model="claude-sonnet-4-6",
+            output=500,
+        ),
+        _record(
+            timestamp=_now() - timedelta(minutes=3),
+            model="claude-haiku-4-5",
+            output=250,
+        ),
+    )
+    await _run_poll(state, tmp_path)
+    assert state.get_state("usage.claude_code.week_tokens")["value"]["current"] == 1750
+    assert (
+        state.get_state("usage.claude_code.week_sonnet_tokens")["value"]["current"]
+        == 500
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-sonnet-4-6",
+        "claude-3-5-sonnet-20241022",
+        "Claude-Sonnet-4",  # case-insensitive
+    ],
+)
+async def test_sonnet_filter_matches_variants(
+    state: StateStore, tmp_path: Path, model: str
+) -> None:
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(minutes=1),
+            model=model,
+            output=100,
+        ),
+    )
+    await _run_poll(state, tmp_path)
+    assert (
+        state.get_state("usage.claude_code.week_sonnet_tokens")["value"]["current"]
+        == 100
+    )
+
+
+# ----------------------------------------------------------------- caps ----
+
+
+async def test_percent_computed_when_cap_set(state: StateStore, tmp_path: Path) -> None:
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(minutes=1),
+            model="claude-opus-4-7",
+            output=250,
+        ),
+    )
+    caps = {
+        "session_tokens": 1000,
+        "week_tokens": None,
+        "week_sonnet_tokens": None,
+    }
+    await _run_poll(state, tmp_path, caps=caps)
+    entry = state.get_state("usage.claude_code.session_tokens")["value"]
+    assert entry["current"] == 250
+    assert entry["max"] == 1000
+    assert entry["percent"] == 25.0
+    # Cap-less metric still null.
+    assert state.get_state("usage.claude_code.week_tokens")["value"]["percent"] is None
+
+
+async def test_zero_or_negative_cap_treated_as_unset(
+    state: StateStore, tmp_path: Path
+) -> None:
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(minutes=1),
+            model="claude-opus-4-7",
+            output=10,
+        ),
+    )
+    # _optional_int filters non-positive values; pass through what register() would.
+    caps = {
+        "session_tokens": ccu._optional_int(0),
+        "week_tokens": ccu._optional_int(-1),
+        "week_sonnet_tokens": ccu._optional_int(None),
+    }
+    await _run_poll(state, tmp_path, caps=caps)
+    for key in (
+        "usage.claude_code.session_tokens",
+        "usage.claude_code.week_tokens",
+        "usage.claude_code.week_sonnet_tokens",
+    ):
+        assert state.get_state(key)["value"]["percent"] is None
+
+
+# ----------------------------------------------------------- empty state ----
+
+
+async def test_no_data_dir_publishes_zero_metrics(
+    state: StateStore, tmp_path: Path
+) -> None:
+    # tmp_path has no projects/ subdir → poller publishes zeroes.
+    await _run_poll(state, tmp_path)
+    for key in (
+        "usage.claude_code.session_tokens",
+        "usage.claude_code.week_tokens",
+        "usage.claude_code.week_sonnet_tokens",
+    ):
+        assert state.get_state(key)["value"]["current"] == 0

--- a/tests/test_claude_code_usage.py
+++ b/tests/test_claude_code_usage.py
@@ -140,6 +140,29 @@ async def test_state_value_shape(state: StateStore, tmp_path: Path) -> None:
 # --------------------------------------------------------- token counting --
 
 
+def test_token_total_floors_negative_components_at_zero() -> None:
+    """A single negative field must not subtract from the running sum."""
+    total = ccu._token_total(
+        {
+            "input_tokens": -10,
+            "cache_creation_input_tokens": 50,
+            "output_tokens": 100,
+        }
+    )
+    assert total == 150  # not 140
+
+
+def test_token_total_handles_non_numeric_fields() -> None:
+    total = ccu._token_total(
+        {
+            "input_tokens": "garbage",
+            "cache_creation_input_tokens": None,
+            "output_tokens": 7,
+        }
+    )
+    assert total == 7
+
+
 async def test_token_total_excludes_cache_read(
     state: StateStore, tmp_path: Path
 ) -> None:
@@ -364,7 +387,111 @@ async def test_zero_or_negative_cap_treated_as_unset(
         assert state.get_state(key)["value"]["percent"] is None
 
 
+@pytest.mark.parametrize("raw_cap", [0, -100])
+async def test_publish_defends_against_unfiltered_non_positive_cap(
+    state: StateStore, tmp_path: Path, raw_cap: int
+) -> None:
+    """If a caller bypasses _optional_int and passes 0 / -N straight in,
+    _publish's own ``cap and cap > 0`` guard must still hold percent to None."""
+    _seed(
+        tmp_path,
+        _record(
+            timestamp=_now() - timedelta(minutes=1),
+            model="claude-opus-4-7",
+            output=10,
+        ),
+    )
+    caps = {
+        "session_tokens": raw_cap,  # raw value, not run through _optional_int
+        "week_tokens": None,
+        "week_sonnet_tokens": None,
+    }
+    await _run_poll(state, tmp_path, caps=caps)
+    entry = state.get_state("usage.claude_code.session_tokens")["value"]
+    assert entry["percent"] is None
+    # max is whatever the caller passed (0 or negative) — _publish only
+    # gates the percent computation, not the max field.
+    assert entry["max"] == raw_cap
+
+
 # ----------------------------------------------------------- empty state ----
+
+
+def test_clamp_warns_on_below_minimum(
+    state: StateStore,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Misconfigured values are clamped AND logged so the operator notices."""
+    import logging as _logging
+
+    caplog.set_level(_logging.WARNING, logger=ccu.logger.name)
+    poller = ccu.UsagePoller(
+        registry=_registry_stub(state),
+        data_dir=tmp_path,
+        poll_interval=0.1,  # below 1.0 floor
+        session_window_hours=0.0001,  # below 60s floor
+        caps={"session_tokens": None, "week_tokens": None, "week_sonnet_tokens": None},
+    )
+    assert poller._poll_interval == ccu._MIN_POLL_INTERVAL_SEC
+    assert poller._session_window_sec == ccu._MIN_SESSION_WINDOW_SEC
+
+    warnings = [r.message for r in caplog.records if r.levelno == _logging.WARNING]
+    assert any("poll_interval_seconds" in m for m in warnings), warnings
+    assert any("session_window_hours" in m for m in warnings), warnings
+
+
+async def test_register_holds_strong_reference_to_background_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``register()`` must keep the polling task alive past the call.
+
+    asyncio.create_task only weakly references the returned task; without
+    storing a strong ref the task can be garbage-collected before it ever
+    runs. This test asserts the module-level set is populated and that
+    the task self-removes when cancelled.
+    """
+    # Sandbox: no config.toml in tmp_path, point data_dir at tmp_path.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DECKHAND_CONFIG_FILE", raising=False)
+    monkeypatch.setattr(ccu, "_DEFAULT_DATA_DIR", str(tmp_path))
+
+    # Stub registry whose state is a real StateStore.
+    registry = _registry_stub(StateStore(EventBus()))
+
+    ccu._BACKGROUND_TASKS.clear()
+    ccu.register(registry)
+    assert len(ccu._BACKGROUND_TASKS) == 1
+
+    # Cancel + await so the task settles cleanly; done callback should
+    # drain the strong-ref set.
+    task = next(iter(ccu._BACKGROUND_TASKS))
+    task.cancel()
+    try:
+        await task
+    except BaseException:
+        pass
+    assert len(ccu._BACKGROUND_TASKS) == 0
+
+
+def test_clamp_silent_when_above_minimum(
+    state: StateStore,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A reasonable config must NOT log a clamp warning."""
+    import logging as _logging
+
+    caplog.set_level(_logging.WARNING, logger=ccu.logger.name)
+    ccu.UsagePoller(
+        registry=_registry_stub(state),
+        data_dir=tmp_path,
+        poll_interval=30,
+        session_window_hours=5,
+        caps={"session_tokens": None, "week_tokens": None, "week_sonnet_tokens": None},
+    )
+    assert not any("below minimum" in str(r.message).lower() for r in caplog.records)
 
 
 async def test_no_data_dir_publishes_zero_metrics(


### PR DESCRIPTION
The first real built-in plugin. Polls Claude Code's per-session JSONL logs (`~/.claude/projects/**/*.jsonl`) and publishes three normalized token-usage state keys so a Data Widget button can display them.

## Metrics

| state key | window | model filter | configurable cap |
|---|---|---|---|
| `usage.claude_code.session_tokens` | rolling 5h | all | `session_token_cap` |
| `usage.claude_code.week_tokens` | rolling 7d | all | `week_token_cap` |
| `usage.claude_code.week_sonnet_tokens` | rolling 7d | case-insensitive `sonnet` in model id | `week_sonnet_token_cap` |

Each value matches the shape from #23/#22: `{ label, current, max, percent, unit, updated_at }`.

## Heuristics (all documented in the module docstring)

- **Token formula:** `input_tokens + cache_creation_input_tokens + output_tokens`. `cache_read` is excluded because cache reads aren't billed at full rate.
- **Session window:** rolling 5h from now. Approximation of Claude's own session concept — agrees with `/usage` during active use, diverges if you've been idle. Configurable via `session_window_hours`.
- **Week window:** rolling 7 days. Matches Anthropic's Sonnet weekly cap behaviour better than a calendar-week aggregation.
- **Sonnet filter:** case-insensitive substring (`claude-sonnet-4-6`, `claude-3-5-sonnet`, `Claude-Sonnet-4` all match).

## Constraint called out up front

**No cap info is anywhere on disk.** Anthropic's server tells Claude's UI the percentages; the local files only know how much you've spent. So `max` and `percent` are `null` unless the user configures expected caps in the new `[plugins.claude_code_usage]` config block. `config.example.toml` is updated with a fully commented block describing every knob and the cap-vs-no-cap behaviour.

## Performance

Session logs are mtime-prefiltered against the 7d window before parsing — files for inactive projects are never read. Live smoke against my own `~/.claude` completes in well under a second and returns realistic numbers (1.46M tokens in the last 5h, 7.09M in the last 7d, 0 Sonnet — I've been on Opus this week).

## Known limitation

The polling task is spawned at `register()` and never cancelled. On plugin reload it leaks until the service exits. Intentional for v1; will be cleaned up alongside the broader plugin shutdown hook tracked in #29.

## Test plan

- 19 new tests in `tests/test_claude_code_usage.py` covering:
  - All three metrics get published, with the correct value shape and units.
  - Token formula excludes `cache_read_input_tokens` (test value `9999` proves it doesn't appear in `current`).
  - Records without `usage` (file-history-snapshot, user role messages) are skipped.
  - Malformed JSON lines are skipped without aborting the parse.
  - 5h session window: a record 10h old appears in `week_tokens` but not `session_tokens`.
  - 7d mtime prefilter: a session file mtime-set 20 days old is skipped entirely.
  - Sonnet filter across three model id variants (parametrized).
  - Caps wire through to `percent` correctly (250 / 1000 → 25.0%).
  - Zero / negative / `None` caps all treated as "unset" → `percent` stays `null`.
  - Empty data dir baseline: poller publishes three zero metrics rather than erroring.
- `make check`: ruff lint clean, ruff format clean, **189 tests passing** (170 → 189, +19).
- Live integration smoke against real `~/.claude` data published believable numbers.

Closes #21
