### PR TITLE
Cursor focuser + pending_input mirror

### DIFF
--- a/examples/cursor_hooks.json
+++ b/examples/cursor_hooks.json
@@ -30,7 +30,8 @@
     ],
     "stop": [
       {
-        "command": "jq -c '{session_id, hook_event_name: \"stop\", cwd: .workspace_roots[0] // .cwd // empty}' | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/cursor/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
+        "_comment": "On `stop` we set deckhand_status=awaiting_input. Cursor lacks an explicit `agent is waiting for the user` event (unlike Claude Code's `Notification`), so `stop` — the agent finished a turn and the user is now the bottleneck — is the right semantic for the focus_next_pending button to surface this session as needing attention. Edit this override if you want a different mapping.",
+        "command": "jq -c '{session_id, hook_event_name: \"stop\", cwd: .workspace_roots[0] // .cwd // empty, deckhand_status: \"awaiting_input\"}' | curl -sS -X POST \"${DECKHAND_URL:-http://127.0.0.1:8000}/agents/cursor/hook\" -H \"Authorization: Bearer ${DECKHAND_API_KEY}\" -H 'Content-Type: application/json' --data-binary @- >/dev/null || true"
       }
     ],
     "sessionEnd": [

--- a/src/deckhand/focusers/cursor.py
+++ b/src/deckhand/focusers/cursor.py
@@ -1,0 +1,80 @@
+"""Cursor IDE focuser via the macOS ``open`` command.
+
+We use ``open -a Cursor <workspace_path>`` rather than AppleScript
+window-walking because Cursor exposes no per-workspace identifier
+through its AppleScript surface — the only available signal is the
+window title, which mutates (unsaved-indicator dots, multi-root names,
+arbitrary user-set tab text) and is unreliable for matching. ``open -a``
+hands the routing decision to Cursor itself: if a window is already
+showing the workspace, that window is raised; otherwise Cursor opens
+one. The call is one short subprocess spawn with no script to template
+and no escaping concerns.
+
+Precision actually achieved:
+
+* **Cursor running + workspace already open:** the existing window is
+  raised. Common case during normal use.
+* **Cursor running + workspace not open:** Cursor opens a new window
+  for it. Arguably surprising in a "focus" action, but doing nothing
+  is worse for the ``focus_next_pending`` flow than reopening.
+* **Cursor not running:** it launches with the workspace open.
+* **No ``project_root`` available:** the focuser falls back to a bare
+  ``open -a Cursor`` which raises Cursor's frontmost window. Useful
+  when the originating hook payload omitted ``cwd``.
+
+The focuser never raises: missing ``open`` binary, subprocess timeout,
+and non-zero exit codes are all logged and swallowed.
+``agents.focus_next_pending`` moves on to the next pending agent if a
+focuser fails or hangs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+_OPEN_TIMEOUT_SECONDS = 5.0
+
+
+def make_cursor_focuser(project_root: str | None):
+    """Build an async focuser callable for a Cursor session.
+
+    ``project_root`` is the workspace path the focuser will target on
+    invocation. Passing ``None`` falls back to activating the Cursor
+    app without a workspace switch.
+    """
+
+    async def focuser() -> None:
+        await asyncio.to_thread(_open_cursor, project_root)
+
+    return focuser
+
+
+def _open_cursor(project_root: str | None) -> None:
+    cmd = ["open", "-a", "Cursor"]
+    if project_root:
+        cmd.append(project_root)
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_OPEN_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        logger.warning("`open` not available; cursor focuser is a no-op")
+        return
+    except subprocess.TimeoutExpired:
+        logger.warning("cursor focuser timed out for project_root=%s", project_root)
+        return
+
+    if result.returncode != 0:
+        logger.warning(
+            "cursor focuser exited %s for project_root=%s: %s",
+            result.returncode,
+            project_root,
+            (result.stderr or "").strip(),
+        )

--- a/src/deckhand/main.py
+++ b/src/deckhand/main.py
@@ -27,6 +27,7 @@ from deckhand.agents.pending_input import PendingInputTracker
 from deckhand.agents.summary import update_cursor_summary
 from deckhand.config.settings import Settings
 from deckhand.event_log import EventLogger
+from deckhand.focusers.cursor import make_cursor_focuser
 from deckhand.focusers.iterm import make_iterm_focuser
 from deckhand.logging_config import configure_logging
 from deckhand.metrics import Metrics
@@ -598,6 +599,7 @@ async def cursor_hook(payload: CursorHookPayload) -> dict[str, object]:
             title=payload.title,
         )
         orchestrator.register_agent(agent)
+        orchestrator.register_focuser(agent_id, make_cursor_focuser(payload.cwd))
         await orchestrator.event_bus.emit(
             build_event(
                 "agent.registered",
@@ -609,6 +611,11 @@ async def cursor_hook(payload: CursorHookPayload) -> dict[str, object]:
         agent = existing  # type: ignore[assignment]
         if payload.cwd and agent.project_root != payload.cwd:
             agent.project_root = payload.cwd
+            # Rebind the focuser so a workspace switch mid-session takes
+            # effect on the next focus invocation. Building the closure is
+            # microsecond-cheap; mirrors the late-binding pattern in the
+            # Claude Code hook handler above.
+            orchestrator.register_focuser(agent_id, make_cursor_focuser(payload.cwd))
         if payload.title and getattr(agent, "title", None) != payload.title:
             agent.title = payload.title  # type: ignore[attr-defined]
 

--- a/tests/test_cursor_hook_api.py
+++ b/tests/test_cursor_hook_api.py
@@ -111,3 +111,150 @@ async def test_focus_cursor_agent_action(client: AsyncClient) -> None:
         json={"agent_id": "cursor-11111111"},
     )
     assert resp.status_code == 200
+
+
+async def test_hook_registers_cursor_focuser_on_session_start(
+    client: AsyncClient,
+) -> None:
+    """sessionStart must wire a focuser into the orchestrator so the agent is
+    reachable via agents.focus_next_pending."""
+    import deckhand.main as main_mod
+
+    await client.post(
+        "/agents/cursor/hook",
+        json={
+            "session_id": "22222222aaaaaaaa",
+            "hook_event_name": "sessionStart",
+            "cwd": "/tmp/beta",
+        },
+    )
+
+    assert "cursor-22222222" in main_mod.orchestrator.focusers
+
+
+async def test_hook_rebinds_cursor_focuser_when_workspace_changes(
+    client: AsyncClient,
+) -> None:
+    """If the workspace path changes mid-session (rare but valid — multi-root
+    workspaces or a user switching roots), the focuser must rebind so the
+    next focus call lands on the new workspace."""
+    import deckhand.main as main_mod
+
+    session = {"session_id": "33333333bbbbbbbb"}
+    await client.post(
+        "/agents/cursor/hook",
+        json={**session, "hook_event_name": "sessionStart", "cwd": "/tmp/before"},
+    )
+    first = main_mod.orchestrator.focusers.get("cursor-33333333")
+
+    await client.post(
+        "/agents/cursor/hook",
+        json={
+            **session,
+            "hook_event_name": "beforeSubmitPrompt",
+            "cwd": "/tmp/after",
+        },
+    )
+    second = main_mod.orchestrator.focusers.get("cursor-33333333")
+
+    assert second is not None
+    assert second is not first
+
+
+async def test_focus_next_pending_cycles_through_mixed_cursor_and_claude(
+    client: AsyncClient,
+) -> None:
+    """Acceptance test from #24: mixed Claude + Cursor pending sessions both
+    surface in agents.pending_input and are reached by successive
+    focus_next_pending calls."""
+    import deckhand.main as main_mod
+
+    # Register a Cursor agent and drive it to awaiting_input via the
+    # documented hook-config opt-in (deckhand_status=awaiting_input on stop).
+    await client.post(
+        "/agents/cursor/hook",
+        json={
+            "session_id": "cccccccc11111111",
+            "hook_event_name": "sessionStart",
+            "cwd": "/tmp/cursor-project",
+        },
+    )
+    await client.post(
+        "/agents/cursor/hook",
+        json={
+            "session_id": "cccccccc11111111",
+            "hook_event_name": "stop",
+            "cwd": "/tmp/cursor-project",
+            "deckhand_status": "awaiting_input",
+        },
+    )
+
+    # Register a Claude Code agent and drive it to awaiting_input.
+    await client.post(
+        "/agents/claude-code/hook",
+        json={
+            "session_id": "dddddddd22222222",
+            "hook_event_name": "SessionStart",
+            "cwd": "/tmp/cc-project",
+            "iterm_session_id": "cc-iterm-uuid",
+        },
+    )
+    await client.post(
+        "/agents/claude-code/hook",
+        json={
+            "session_id": "dddddddd22222222",
+            "hook_event_name": "Notification",
+            "iterm_session_id": "cc-iterm-uuid",
+        },
+    )
+
+    # Both should appear in pending_input. Cursor registered first → head.
+    pending_resp = await client.get("/state/agents.pending_input")
+    pending = pending_resp.json()["value"]["agent_ids"]
+    assert "cursor-cccccccc" in pending
+    assert "claude-code-dddddddd" in pending
+
+    # Stub both focusers so the test doesn't actually launch apps.
+    fired: list[str] = []
+
+    async def fake_cursor() -> None:
+        fired.append("cursor")
+
+    async def fake_claude() -> None:
+        fired.append("claude")
+
+    main_mod.orchestrator.register_focuser("cursor-cccccccc", fake_cursor)
+    main_mod.orchestrator.register_focuser("claude-code-dddddddd", fake_claude)
+
+    # Each press of the focus_next_pending button focuses the head, then
+    # the head resolves (status leaves awaiting_input) and the next press
+    # hits the other agent. Simulate the resolution manually by driving
+    # each focused agent's status off awaiting_input.
+    first_focused = await main_mod.orchestrator.focus_next_pending()
+    assert first_focused in {"cursor-cccccccc", "claude-code-dddddddd"}
+
+    # Resolve the first focused agent so the next press cycles to the other.
+    if first_focused == "cursor-cccccccc":
+        await client.post(
+            "/agents/cursor/hook",
+            json={
+                "session_id": "cccccccc11111111",
+                "hook_event_name": "beforeSubmitPrompt",
+                "cwd": "/tmp/cursor-project",
+            },
+        )
+        expected_next = "claude-code-dddddddd"
+    else:
+        await client.post(
+            "/agents/claude-code/hook",
+            json={
+                "session_id": "dddddddd22222222",
+                "hook_event_name": "UserPromptSubmit",
+                "iterm_session_id": "cc-iterm-uuid",
+            },
+        )
+        expected_next = "cursor-cccccccc"
+
+    second_focused = await main_mod.orchestrator.focus_next_pending()
+    assert second_focused == expected_next
+    assert set(fired) == {"cursor", "claude"}

--- a/tests/test_focusers.py
+++ b/tests/test_focusers.py
@@ -6,6 +6,7 @@ import subprocess
 from unittest.mock import patch
 
 from deckhand.agents.mock import MockAgent
+from deckhand.focusers.cursor import make_cursor_focuser
 from deckhand.focusers.iterm import _build_applescript, make_iterm_focuser
 from deckhand.orchestrator.focusers import FocuserRegistry
 from deckhand.orchestrator.manager import Orchestrator
@@ -245,5 +246,63 @@ async def test_iterm_focuser_swallows_timeout() -> None:
     with patch(
         "subprocess.run",
         side_effect=subprocess.TimeoutExpired(cmd="osascript", timeout=5),
+    ):
+        await focuser()  # must not raise
+
+
+# ---------------------------------------------------------- Cursor focuser ---
+
+
+async def test_cursor_focuser_invokes_open_with_workspace_path() -> None:
+    focuser = make_cursor_focuser("/Users/me/projects/alpha")
+
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", return_value=completed) as run:
+        await focuser()
+
+    assert run.call_count == 1
+    args, kwargs = run.call_args
+    cmd = args[0]
+    assert cmd == ["open", "-a", "Cursor", "/Users/me/projects/alpha"]
+    assert kwargs.get("timeout") == 5
+
+
+async def test_cursor_focuser_without_workspace_just_activates_app() -> None:
+    """No project_root → just `open -a Cursor` with no path argument.
+
+    This is the fallback for hook payloads that omitted cwd. The expected
+    behaviour is "raise Cursor's frontmost window" rather than a no-op,
+    because doing nothing produces a worse UX than activating the app.
+    """
+    focuser = make_cursor_focuser(None)
+
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", return_value=completed) as run:
+        await focuser()
+
+    cmd = run.call_args.args[0]
+    assert cmd == ["open", "-a", "Cursor"]
+
+
+async def test_cursor_focuser_swallows_nonzero_exit() -> None:
+    focuser = make_cursor_focuser("/tmp/p")
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="Cursor not found"
+    )
+    with patch("subprocess.run", return_value=completed):
+        await focuser()  # must not raise
+
+
+async def test_cursor_focuser_swallows_missing_open_binary() -> None:
+    focuser = make_cursor_focuser("/tmp/p")
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        await focuser()  # must not raise
+
+
+async def test_cursor_focuser_swallows_timeout() -> None:
+    focuser = make_cursor_focuser("/tmp/p")
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="open", timeout=5),
     ):
         await focuser()  # must not raise


### PR DESCRIPTION
Mirrors what #23 did for Claude Code + iTerm: a Cursor session that becomes `awaiting_input` surfaces in `agents.pending_input` and is reachable via the `agents.focus_next_pending` action.

## Investigation findings (per the ticket)

**Cursor lacks a direct equivalent to Claude Code's `Notification` event** (the explicit "agent is waiting on the user" signal). The closest semantic Cursor exposes is `stop` — the agent has finished a turn and the next move is the user's.

Rather than change the in-code default mapping in `CursorAgent` (where `stop` literally means "stopped a turn"), the example hook config opts into the `awaiting_input` semantic by setting `deckhand_status: "awaiting_input"` on the `stop` event. The override is documented inline so users editing their own hook config understand why and can choose differently. This keeps the agent-class mapping faithful to event semantics while making the example config produce the UX this feature exists to enable.

**Focuser approach: `open -a Cursor <workspace>` rather than AppleScript window-walking.** Cursor exposes no per-workspace identifier through its AppleScript surface — the only match-able field is the window title, which mutates (unsaved-indicator dots, multi-root names, arbitrary user-set tab text) and is unreliable. `open -a` hands the routing to Cursor itself: if a window is already showing the workspace it's raised, otherwise Cursor opens one. One subprocess spawn, no script template, no escaping concerns. The module docstring spells out the precision actually achieved per scenario.

## What ships

- New `src/deckhand/focusers/cursor.py` — `make_cursor_focuser(project_root)` returns an async no-arg closure. Falls back to bare app activation when `project_root` is None. Missing `open` binary, subprocess timeout, and non-zero exit codes are all logged and swallowed — same contract as the iTerm focuser.
- `main.cursor_hook` registers a focuser on `sessionStart` and rebinds it when `cwd` changes mid-session (workspace switch, multi-root). Same late-binding pattern the Claude Code hook uses for iTerm.
- `examples/cursor_hooks.json` `stop` hook now carries `deckhand_status: "awaiting_input"`, with an inline `_comment` explaining the choice and that users can edit it.

## Test plan

- `make check` — 208 passed (+8 from this PR), lint clean.
- Unit tests for the cursor focuser (parallel to the iTerm tests): invokes `open` with workspace path; falls back to bare activation; swallows nonzero exit / missing binary / timeout.
- Hook-API tests: focuser registered on `sessionStart`; rebound when `cwd` changes mid-session.
- **Acceptance test for #24's "mixed Claude + Cursor cycling reaches both":** drives one Claude Code agent to `awaiting_input` via the `Notification` event and one Cursor agent to `awaiting_input` via `stop` + `deckhand_status` override; asserts both appear in `agents.pending_input`; calls `focus_next_pending`, resolves the head, calls again, asserts both stubbed focusers fired exactly once.

Closes #24
