### PR TITLE
Drop deckhand.env; share config.toml across service, CLI, and OpenDeck plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := help
 
 BRANCH_PROD := main
-SRC_DIRS    := src/ tests/
+SRC_DIRS    := src/ tests/ opendeck-plugin/
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -22,6 +22,7 @@ cli: ## Run the deckhand CLI (pass ARGS="..." for arguments)
 
 test: ## Run test suite
 	uv run --extra test pytest tests/ -v --asyncio-mode=auto
+	uv run --extra test pytest opendeck-plugin/tests/ -v --asyncio-mode=auto --rootdir=opendeck-plugin
 
 lint: ## Run ruff linter
 	uvx ruff check $(SRC_DIRS)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cp -r opendeck-plugin/com.deckhand.plugin.sdPlugin \
   ~/.config/OpenDeck/Plugins/
 ```
 
-OpenDeck's plugin loader expects a `deckhand.env` file next to the plugin. Either copy `deckhand.env.example` and set `DECKHAND_API_KEY` there, or symlink it to your shell's environment.
+The plugin reads its `DECKHAND_URL` and `DECKHAND_API_KEY` from the same `config.toml` the service uses — put them under a `[client]` section. If you don't have a service checkout (OpenDeck-plugin-only install), put the file at `~/.config/deckhand/config.toml`; the service and the plugin both look there as a fallback. See `config.example.toml` for the section shape. The `DECKHAND_URL` / `DECKHAND_API_KEY` env vars override the file if you'd rather set them at the shell level.
 
 **4. Restart OpenDeck.** A "Deckhand" category appears in the action list.
 
@@ -161,7 +161,7 @@ Connection settings come from `--url` / `--api-key`, then `DECKHAND_URL` / `DECK
 | Plugin modules | `DECKHAND_PLUGINS` | none (opt in via `config.toml`) |
 | State persistence file | `DECKHAND_STATE_FILE` | none (in-memory) |
 | Event log | `DECKHAND_EVENT_LOG_ENABLED` / `DECKHAND_EVENT_LOG` | off; `.deckhand/events.log` |
-| Config file path | `DECKHAND_CONFIG_FILE` | `./config.toml` if present |
+| Config file path | `DECKHAND_CONFIG_FILE` | `./config.toml`, then `~/.config/deckhand/config.toml` |
 
 `config.example.toml` is the annotated reference for every section.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,7 +1,15 @@
 # Deckhand Configuration File Example
 #
 # Copy this file to config.toml and customize as needed.
-# Or set DECKHAND_CONFIG_FILE environment variable to point to your config file.
+#
+# Config file discovery order (first hit wins):
+#   1. DECKHAND_CONFIG_FILE env var
+#   2. ./config.toml
+#   3. ~/.config/deckhand/config.toml
+#
+# Tip: if you only run the OpenDeck plugin (no service checkout), put this
+# file at ~/.config/deckhand/config.toml — the plugin reads the [client]
+# section from the same file.
 
 [service]
 name = "deckhand"
@@ -46,6 +54,16 @@ modules = [
 #   { key = "your-write-key-here", scope = "write" },
 #   { key = "your-read-key-here", scope = "read" },
 # ]
+
+[client]
+# Values clients (the OpenDeck plugin, the `deckhand` CLI, anything else
+# that connects to a running Deckhand service) read from this file. The
+# service itself ignores this section — its own accepted keys come from
+# [auth].api_keys above. Putting both in one file means there's no second
+# config surface to keep in sync.
+#
+# url = "http://127.0.0.1:8000"
+# api_key = "your-write-key-here"   # same value as one of [auth].api_keys
 
 [rate_limit]
 # Maximum requests per minute per client IP (default: 60)

--- a/opendeck-plugin/README.md
+++ b/opendeck-plugin/README.md
@@ -20,12 +20,18 @@ cp -r com.deckhand.plugin.sdPlugin ~/Library/Application\ Support/OpenDeck/Plugi
 cp -r com.deckhand.plugin.sdPlugin ~/.config/OpenDeck/Plugins/
 ```
 
-Configure auth so the plugin can reach Deckhand Core:
+Configure auth so the plugin can reach Deckhand Core. The plugin reads `DECKHAND_URL` and `DECKHAND_API_KEY` in this order (first hit wins):
 
-```bash
-cd ~/Library/Application\ Support/OpenDeck/Plugins/com.deckhand.plugin.sdPlugin
-cp deckhand.env.example deckhand.env
-# Set DECKHAND_API_KEY to the same value as Deckhand Core (config.toml or .env)
+1. The `DECKHAND_URL` / `DECKHAND_API_KEY` env vars (useful if you launch the plugin from a wrapper script or `launchctl setenv`).
+2. The `[client]` section of the shared `config.toml`. Discovery order matches the Deckhand Core service: `DECKHAND_CONFIG_FILE` env var, then `./config.toml` (relative to the plugin's working dir), then `~/.config/deckhand/config.toml`. The home path is the intended location for OpenDeck-plugin-only installs.
+3. A legacy `deckhand.env` file next to `plugin.py` — kept working for one release as a deprecation path. The plugin logs a warning when it falls back to this file.
+
+The simplest fresh install just edits `~/.config/deckhand/config.toml`:
+
+```toml
+[client]
+url = "http://127.0.0.1:8000"
+api_key = "your-write-key"   # same value as one of [auth].api_keys
 ```
 
 Then restart OpenDeck. A "Deckhand" category should appear with six actions:
@@ -114,7 +120,10 @@ Run the plugin directly (bypassing OpenDeck, for testing):
 
 ```bash
 cd com.deckhand.plugin.sdPlugin
-cp deckhand.env.example deckhand.env   # set DECKHAND_API_KEY
+# Connection settings come from one of the sources above. The fastest path
+# for local dev is to export the env vars in the same shell:
+export DECKHAND_URL=http://127.0.0.1:8000
+export DECKHAND_API_KEY=<your-key>
 ./run.sh -port 28196 -pluginUUID test -registerEvent registerPlugin -info '{}'
 ```
 

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/action_run.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/action_run.py
@@ -23,7 +23,12 @@ class ActionRunHandler:
     def __init__(self, bridge: DeckhandBridge) -> None:
         self.bridge = bridge
 
-    async def on_will_appear(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_will_appear(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         action_name = settings.get("action_name", "")
         if action_name:
             await _set_title(ws, context, action_name.split(".")[-1])
@@ -33,7 +38,12 @@ class ActionRunHandler:
     async def on_will_disappear(self, context: str) -> None:
         pass
 
-    async def on_key_down(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_key_down(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         action_name = settings.get("action_name", "")
         if not action_name:
             return
@@ -43,22 +53,35 @@ class ActionRunHandler:
             payload = json.loads(payload_str) if payload_str else {}
         except json.JSONDecodeError:
             payload = {}
-            logger.warning("Invalid JSON payload for action %s: %s", action_name, payload_str)
+            logger.warning(
+                "Invalid JSON payload for action %s: %s", action_name, payload_str
+            )
 
         try:
             await self.bridge.execute_action(action_name, payload)
             await _set_title(ws, context, "OK!")
             import asyncio
+
             await asyncio.sleep(0.5)
             await _set_title(ws, context, action_name.split(".")[-1])
         except Exception:
             logger.exception("Failed to execute action %s", action_name)
             await _set_title(ws, context, "Error")
 
-    async def on_did_receive_settings(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_did_receive_settings(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         await self.on_will_appear(ws, context, settings)
 
-    async def on_send_to_plugin(self, ws: websockets.asyncio.client.ClientConnection, context: str, payload: dict[str, Any]) -> None:
+    async def on_send_to_plugin(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        payload: dict[str, Any],
+    ) -> None:
         """Handle Property Inspector requests (e.g., fetch action list)."""
         if payload.get("type") == "getActions":
             try:
@@ -66,28 +89,52 @@ class ActionRunHandler:
                 async with session.get(f"{self.bridge.base_url}/actions") as resp:
                     resp.raise_for_status()
                     data = await resp.json()
-                await _send_to_property_inspector(ws, context, {
-                    "type": "actionList",
-                    "actions": data.get("actions", []),
-                })
+                await _send_to_property_inspector(
+                    ws,
+                    context,
+                    {
+                        "type": "actionList",
+                        "actions": data.get("actions", []),
+                    },
+                )
             except Exception:
                 logger.exception("Failed to fetch actions for PI")
 
-    async def on_deckhand_event(self, ws: websockets.asyncio.client.ClientConnection, event_type: str, event: dict[str, Any], all_contexts: dict[str, dict[str, Any]]) -> None:
+    async def on_deckhand_event(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        event_type: str,
+        event: dict[str, Any],
+        all_contexts: dict[str, dict[str, Any]],
+    ) -> None:
         pass  # Action run doesn't react to Deckhand events
 
 
-async def _set_title(ws: websockets.asyncio.client.ClientConnection, context: str, title: str) -> None:
-    await ws.send(json.dumps({
-        "event": "setTitle",
-        "context": context,
-        "payload": {"title": title},
-    }))
+async def _set_title(
+    ws: websockets.asyncio.client.ClientConnection, context: str, title: str
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "setTitle",
+                "context": context,
+                "payload": {"title": title},
+            }
+        )
+    )
 
 
-async def _send_to_property_inspector(ws: websockets.asyncio.client.ClientConnection, context: str, payload: dict[str, Any]) -> None:
-    await ws.send(json.dumps({
-        "event": "sendToPropertyInspector",
-        "context": context,
-        "payload": payload,
-    }))
+async def _send_to_property_inspector(
+    ws: websockets.asyncio.client.ClientConnection,
+    context: str,
+    payload: dict[str, Any],
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "sendToPropertyInspector",
+                "context": context,
+                "payload": payload,
+            }
+        )
+    )

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_dashboard.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_dashboard.py
@@ -29,7 +29,9 @@ _STATUS_EMOJI = {
 
 
 def _dashboard_title(agents: list[dict[str, Any]], agent_filter: str) -> str:
-    filtered = [a for a in agents if agent_filter in ("", "*") or a.get("type") == agent_filter]
+    filtered = [
+        a for a in agents if agent_filter in ("", "*") or a.get("type") == agent_filter
+    ]
     if not filtered:
         return "No Agents"
 

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_ranking.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_ranking.py
@@ -50,9 +50,7 @@ def agent_for_slot(
     return ranked[offset]
 
 
-def needs_attention(
-    agents: list[dict[str, Any]], agent_filter: str = "*"
-) -> bool:
+def needs_attention(agents: list[dict[str, Any]], agent_filter: str = "*") -> bool:
     return any(
         a.get("status") in ATTENTION_STATUSES
         for a in agents

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_status.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/agent_status.py
@@ -27,7 +27,7 @@ STATUS_INDEX = {
 }
 
 STATUS_TITLES = {
-    "idle": "",       # Show agent name when idle
+    "idle": "",  # Show agent name when idle
     "running": "Running",
     "awaiting_input": "Input!",
     "error": "Error",
@@ -38,7 +38,7 @@ STATUS_SOUNDS = {
 }
 
 # Auto-retry defaults
-_RETRY_DELAY = 5.0       # seconds before retry
+_RETRY_DELAY = 5.0  # seconds before retry
 _RETRY_MAX_ATTEMPTS = 3
 
 
@@ -52,7 +52,12 @@ class AgentStatusHandler:
         # context → asyncio.Task for pending retry
         self._retry_tasks: dict[str, asyncio.Task[None]] = {}
 
-    async def on_will_appear(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_will_appear(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         agent_id = settings.get("agent_id", "")
         sounds_enabled = settings.get("sounds_enabled", True)
         auto_retry = settings.get("auto_retry", False)
@@ -89,7 +94,12 @@ class AgentStatusHandler:
         self._watched.pop(context, None)
         self._cancel_retry(context)
 
-    async def on_key_down(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_key_down(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         agent_id = settings.get("agent_id", "")
         if not agent_id:
             return
@@ -118,25 +128,45 @@ class AgentStatusHandler:
         except Exception:
             logger.exception("Key action failed for agent %s", agent_id)
 
-    async def on_did_receive_settings(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_did_receive_settings(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         """Settings changed from Property Inspector — re-initialize."""
         self._cancel_retry(context)
         await self.on_will_appear(ws, context, settings)
 
-    async def on_send_to_plugin(self, ws: websockets.asyncio.client.ClientConnection, context: str, payload: dict[str, Any]) -> None:
+    async def on_send_to_plugin(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        payload: dict[str, Any],
+    ) -> None:
         """Handle Property Inspector requests (e.g., fetch agent list)."""
         request_type = payload.get("type", "")
         if request_type == "getAgents":
             try:
                 agents = await self.bridge.list_agents()
-                await _send_to_property_inspector(ws, context, {
-                    "type": "agentList",
-                    "agents": agents,
-                })
+                await _send_to_property_inspector(
+                    ws,
+                    context,
+                    {
+                        "type": "agentList",
+                        "agents": agents,
+                    },
+                )
             except Exception:
                 logger.exception("Failed to fetch agents for PI")
 
-    async def on_deckhand_event(self, ws: websockets.asyncio.client.ClientConnection, event_type: str, event: dict[str, Any], all_contexts: dict[str, dict[str, Any]]) -> None:
+    async def on_deckhand_event(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        event_type: str,
+        event: dict[str, Any],
+        all_contexts: dict[str, dict[str, Any]],
+    ) -> None:
         """Handle events from Deckhand Core."""
         if event_type not in ("agent.status_changed", "agent.context_changed"):
             return
@@ -177,7 +207,13 @@ class AgentStatusHandler:
 
     # ----- Auto-retry helpers -----
 
-    def _schedule_retry(self, ws: websockets.asyncio.client.ClientConnection, context: str, agent_id: str, info: dict[str, Any]) -> None:
+    def _schedule_retry(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        agent_id: str,
+        info: dict[str, Any],
+    ) -> None:
         """Schedule an auto-retry for a failed agent."""
         retry_count = info.get("retry_count", 0)
         retry_max = info.get("retry_max", _RETRY_MAX_ATTEMPTS)
@@ -193,7 +229,12 @@ class AgentStatusHandler:
         async def _do_retry() -> None:
             await asyncio.sleep(delay)
             try:
-                logger.info("Auto-retrying agent %s (attempt %d/%d)", agent_id, info["retry_count"], retry_max)
+                logger.info(
+                    "Auto-retrying agent %s (attempt %d/%d)",
+                    agent_id,
+                    info["retry_count"],
+                    retry_max,
+                )
                 await self.bridge.start_agent(agent_id)
                 await _set_title(ws, context, f"Retry {info['retry_count']}")
             except Exception:
@@ -212,25 +253,46 @@ class AgentStatusHandler:
 # OpenDeck helper functions
 # ---------------------------------------------------------------------------
 
-async def _set_title(ws: websockets.asyncio.client.ClientConnection, context: str, title: str) -> None:
-    await ws.send(json.dumps({
-        "event": "setTitle",
-        "context": context,
-        "payload": {"title": title},
-    }))
+
+async def _set_title(
+    ws: websockets.asyncio.client.ClientConnection, context: str, title: str
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "setTitle",
+                "context": context,
+                "payload": {"title": title},
+            }
+        )
+    )
 
 
-async def _set_state(ws: websockets.asyncio.client.ClientConnection, context: str, state: int) -> None:
-    await ws.send(json.dumps({
-        "event": "setState",
-        "context": context,
-        "payload": {"state": state},
-    }))
+async def _set_state(
+    ws: websockets.asyncio.client.ClientConnection, context: str, state: int
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "setState",
+                "context": context,
+                "payload": {"state": state},
+            }
+        )
+    )
 
 
-async def _send_to_property_inspector(ws: websockets.asyncio.client.ClientConnection, context: str, payload: dict[str, Any]) -> None:
-    await ws.send(json.dumps({
-        "event": "sendToPropertyInspector",
-        "context": context,
-        "payload": payload,
-    }))
+async def _send_to_property_inspector(
+    ws: websockets.asyncio.client.ClientConnection,
+    context: str,
+    payload: dict[str, Any],
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "sendToPropertyInspector",
+                "context": context,
+                "payload": payload,
+            }
+        )
+    )

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/signal_trigger.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/signal_trigger.py
@@ -22,7 +22,12 @@ class SignalTriggerHandler:
     def __init__(self, bridge: DeckhandBridge) -> None:
         self.bridge = bridge
 
-    async def on_will_appear(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_will_appear(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         signal_name = settings.get("signal_name", "")
         if signal_name:
             await _set_title(ws, context, signal_name.split(".")[-1])
@@ -32,7 +37,12 @@ class SignalTriggerHandler:
     async def on_will_disappear(self, context: str) -> None:
         pass
 
-    async def on_key_down(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_key_down(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         signal_name = settings.get("signal_name", "")
         if not signal_name:
             return
@@ -42,23 +52,36 @@ class SignalTriggerHandler:
             payload = json.loads(payload_str) if payload_str else {}
         except json.JSONDecodeError:
             payload = {}
-            logger.warning("Invalid JSON payload for signal %s: %s", signal_name, payload_str)
+            logger.warning(
+                "Invalid JSON payload for signal %s: %s", signal_name, payload_str
+            )
 
         try:
             await self.bridge.send_signal(signal_name, payload)
             await _set_title(ws, context, "Sent!")
             # Reset title after a short delay
             import asyncio
+
             await asyncio.sleep(0.5)
             await _set_title(ws, context, signal_name.split(".")[-1])
         except Exception:
             logger.exception("Failed to send signal %s", signal_name)
             await _set_title(ws, context, "Error")
 
-    async def on_did_receive_settings(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_did_receive_settings(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         await self.on_will_appear(ws, context, settings)
 
-    async def on_send_to_plugin(self, ws: websockets.asyncio.client.ClientConnection, context: str, payload: dict[str, Any]) -> None:
+    async def on_send_to_plugin(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        payload: dict[str, Any],
+    ) -> None:
         """Handle Property Inspector requests (e.g., fetch signal list)."""
         if payload.get("type") == "getSignals":
             try:
@@ -66,28 +89,52 @@ class SignalTriggerHandler:
                 async with session.get(f"{self.bridge.base_url}/signals") as resp:
                     resp.raise_for_status()
                     data = await resp.json()
-                await _send_to_property_inspector(ws, context, {
-                    "type": "signalList",
-                    "signals": data.get("signals", []),
-                })
+                await _send_to_property_inspector(
+                    ws,
+                    context,
+                    {
+                        "type": "signalList",
+                        "signals": data.get("signals", []),
+                    },
+                )
             except Exception:
                 logger.exception("Failed to fetch signals for PI")
 
-    async def on_deckhand_event(self, ws: websockets.asyncio.client.ClientConnection, event_type: str, event: dict[str, Any], all_contexts: dict[str, dict[str, Any]]) -> None:
+    async def on_deckhand_event(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        event_type: str,
+        event: dict[str, Any],
+        all_contexts: dict[str, dict[str, Any]],
+    ) -> None:
         pass  # Signal trigger doesn't react to Deckhand events
 
 
-async def _set_title(ws: websockets.asyncio.client.ClientConnection, context: str, title: str) -> None:
-    await ws.send(json.dumps({
-        "event": "setTitle",
-        "context": context,
-        "payload": {"title": title},
-    }))
+async def _set_title(
+    ws: websockets.asyncio.client.ClientConnection, context: str, title: str
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "setTitle",
+                "context": context,
+                "payload": {"title": title},
+            }
+        )
+    )
 
 
-async def _send_to_property_inspector(ws: websockets.asyncio.client.ClientConnection, context: str, payload: dict[str, Any]) -> None:
-    await ws.send(json.dumps({
-        "event": "sendToPropertyInspector",
-        "context": context,
-        "payload": payload,
-    }))
+async def _send_to_property_inspector(
+    ws: websockets.asyncio.client.ClientConnection,
+    context: str,
+    payload: dict[str, Any],
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "sendToPropertyInspector",
+                "context": context,
+                "payload": payload,
+            }
+        )
+    )

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/widget.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/actions/widget.py
@@ -25,7 +25,12 @@ class WidgetHandler:
         # context → {"state_key": str, "action_on_press": str, "display_format": str}
         self._watched: dict[str, dict[str, Any]] = {}
 
-    async def on_will_appear(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_will_appear(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         state_key = settings.get("state_key", "")
         action_on_press = settings.get("action_on_press", "")
         display_format = settings.get("display_format", "raw")
@@ -55,7 +60,12 @@ class WidgetHandler:
     async def on_will_disappear(self, context: str) -> None:
         self._watched.pop(context, None)
 
-    async def on_key_down(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_key_down(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         action_name = settings.get("action_on_press", "")
         if not action_name:
             return
@@ -65,25 +75,45 @@ class WidgetHandler:
         except Exception:
             logger.exception("Widget key action failed: %s", action_name)
 
-    async def on_did_receive_settings(self, ws: websockets.asyncio.client.ClientConnection, context: str, settings: dict[str, Any]) -> None:
+    async def on_did_receive_settings(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        settings: dict[str, Any],
+    ) -> None:
         """Settings changed from Property Inspector — re-initialize."""
         await self.on_will_appear(ws, context, settings)
 
-    async def on_send_to_plugin(self, ws: websockets.asyncio.client.ClientConnection, context: str, payload: dict[str, Any]) -> None:
+    async def on_send_to_plugin(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        context: str,
+        payload: dict[str, Any],
+    ) -> None:
         """Handle Property Inspector requests (e.g., fetch state keys)."""
         request_type = payload.get("type", "")
         if request_type == "getStateKeys":
             try:
                 entries = await self.bridge.list_state()
                 keys = [e.get("key", "") for e in entries if e.get("key")]
-                await _send_to_property_inspector(ws, context, {
-                    "type": "stateKeyList",
-                    "keys": keys,
-                })
+                await _send_to_property_inspector(
+                    ws,
+                    context,
+                    {
+                        "type": "stateKeyList",
+                        "keys": keys,
+                    },
+                )
             except Exception:
                 logger.exception("Failed to fetch state keys for PI")
 
-    async def on_deckhand_event(self, ws: websockets.asyncio.client.ClientConnection, event_type: str, event: dict[str, Any], all_contexts: dict[str, dict[str, Any]]) -> None:
+    async def on_deckhand_event(
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        event_type: str,
+        event: dict[str, Any],
+        all_contexts: dict[str, dict[str, Any]],
+    ) -> None:
         """Handle events from Deckhand Core."""
         if event_type != "state.changed":
             return
@@ -108,6 +138,7 @@ class WidgetHandler:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _format_value(value: Any, fmt: str) -> str:
     """Format a state value for display on a button."""
@@ -147,17 +178,31 @@ def _format_value(value: Any, fmt: str) -> str:
     return str(value)[:12]
 
 
-async def _set_title(ws: websockets.asyncio.client.ClientConnection, context: str, title: str) -> None:
-    await ws.send(json.dumps({
-        "event": "setTitle",
-        "context": context,
-        "payload": {"title": title},
-    }))
+async def _set_title(
+    ws: websockets.asyncio.client.ClientConnection, context: str, title: str
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "setTitle",
+                "context": context,
+                "payload": {"title": title},
+            }
+        )
+    )
 
 
-async def _send_to_property_inspector(ws: websockets.asyncio.client.ClientConnection, context: str, payload: dict[str, Any]) -> None:
-    await ws.send(json.dumps({
-        "event": "sendToPropertyInspector",
-        "context": context,
-        "payload": payload,
-    }))
+async def _send_to_property_inspector(
+    ws: websockets.asyncio.client.ClientConnection,
+    context: str,
+    payload: dict[str, Any],
+) -> None:
+    await ws.send(
+        json.dumps(
+            {
+                "event": "sendToPropertyInspector",
+                "context": context,
+                "payload": payload,
+            }
+        )
+    )

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/bridge.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/bridge.py
@@ -12,17 +12,21 @@ import aiohttp
 logger = logging.getLogger("deckhand-bridge")
 
 # Reconnection parameters
-_RECONNECT_BASE_DELAY = 1.0   # seconds
-_RECONNECT_MAX_DELAY = 30.0   # seconds
-_RECONNECT_BACKOFF = 2.0      # multiplier
+_RECONNECT_BASE_DELAY = 1.0  # seconds
+_RECONNECT_MAX_DELAY = 30.0  # seconds
+_RECONNECT_BACKOFF = 2.0  # multiplier
 
 
 class DeckhandBridge:
     """Talks to Deckhand Core over HTTP (actions/state) and WebSocket (events)."""
 
-    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+    def __init__(
+        self, base_url: str = "http://localhost:8000", api_key: str | None = None
+    ) -> None:
         self.base_url = base_url.rstrip("/")
-        ws_base = self.base_url.replace("http://", "ws://").replace("https://", "wss://")
+        ws_base = self.base_url.replace("http://", "ws://").replace(
+            "https://", "wss://"
+        )
         # WebSocket URL no longer carries the token as a query param;
         # authentication happens via a first-message handshake instead.
         self.ws_url = f"{ws_base}/events"
@@ -86,9 +90,7 @@ class DeckhandBridge:
             body["project_root"] = project_root
         if active_file is not None:
             body["active_file"] = active_file
-        async with session.post(
-            f"{self.base_url}/agents/register", json=body
-        ) as resp:
+        async with session.post(f"{self.base_url}/agents/register", json=body) as resp:
             resp.raise_for_status()
             return await resp.json()
 
@@ -112,7 +114,9 @@ class DeckhandBridge:
 
     # ----- HTTP: Actions -----
 
-    async def execute_action(self, action_name: str, payload: dict[str, Any] | None = None) -> None:
+    async def execute_action(
+        self, action_name: str, payload: dict[str, Any] | None = None
+    ) -> None:
         session = await self._get_session()
         async with session.post(
             f"{self.base_url}/actions/{action_name}",
@@ -122,7 +126,9 @@ class DeckhandBridge:
 
     # ----- HTTP: Signals -----
 
-    async def send_signal(self, signal_name: str, payload: dict[str, Any] | None = None) -> None:
+    async def send_signal(
+        self, signal_name: str, payload: dict[str, Any] | None = None
+    ) -> None:
         session = await self._get_session()
         async with session.post(
             f"{self.base_url}/signals/webhook/{signal_name}",
@@ -185,8 +191,13 @@ class DeckhandBridge:
                                 if asyncio.iscoroutine(result):
                                     await result
                             except json.JSONDecodeError:
-                                logger.warning("Invalid JSON from Deckhand Core: %s", msg.data)
-                        elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                                logger.warning(
+                                    "Invalid JSON from Deckhand Core: %s", msg.data
+                                )
+                        elif msg.type in (
+                            aiohttp.WSMsgType.CLOSED,
+                            aiohttp.WSMsgType.ERROR,
+                        ):
                             break
 
             except asyncio.CancelledError:

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/client_config.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/client_config.py
@@ -1,0 +1,130 @@
+"""Resolve OpenDeck plugin connection settings (URL + API key).
+
+Precedence (first hit wins per value):
+
+1. ``DECKHAND_URL`` / ``DECKHAND_API_KEY`` environment variables — the
+   explicit override path. OpenDeck on macOS launches plugins as GUI
+   subprocesses that don't inherit a login shell, so these usually only
+   come from an explicit ``launchctl setenv`` or from being injected by
+   wrapper scripts.
+2. ``[client]`` section of the shared ``config.toml``. Discovery order
+   matches Deckhand Core's: ``DECKHAND_CONFIG_FILE`` env var →
+   ``./config.toml`` (relative to the plugin's working dir) →
+   ``~/.config/deckhand/config.toml``. The home-dir fallback is the
+   intended path for OpenDeck-only users who don't have a Deckhand
+   service checkout.
+3. Legacy ``deckhand.env`` file next to ``plugin.py`` (the pre-#34
+   install pattern). When present, the file is parsed for
+   ``DECKHAND_URL`` / ``DECKHAND_API_KEY`` lines and a deprecation
+   warning is logged. Slated for removal in the release after #34.
+4. Defaults: ``DECKHAND_URL=http://localhost:8000``, ``api_key=None``.
+
+Self-contained on purpose: this module is imported from the plugin
+process running under OpenDeck's bundled venv, which does not have
+``deckhand.*`` on its import path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tomllib
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_URL = "http://localhost:8000"
+
+
+def resolve_connection(plugin_dir: Path) -> tuple[str, str | None]:
+    """Return ``(url, api_key)`` resolved per the precedence above.
+
+    ``plugin_dir`` is the directory containing ``plugin.py`` — used to
+    locate the legacy ``deckhand.env`` file.
+    """
+    url = os.getenv("DECKHAND_URL")
+    api_key = os.getenv("DECKHAND_API_KEY")
+
+    if url is None or api_key is None:
+        shared = _load_shared_client_section()
+        if url is None:
+            url = shared.get("url")
+        if api_key is None:
+            api_key = shared.get("api_key")
+
+    if url is None or api_key is None:
+        legacy = _load_legacy_env_file(plugin_dir / "deckhand.env")
+        if legacy is not None:
+            logger.warning(
+                "Reading connection settings from deckhand.env — this fallback "
+                "is deprecated and will be removed in the next release. Move "
+                "the values to ~/.config/deckhand/config.toml under [client], "
+                "or set DECKHAND_URL / DECKHAND_API_KEY in the environment."
+            )
+            if url is None:
+                url = legacy.get("DECKHAND_URL")
+            if api_key is None:
+                api_key = legacy.get("DECKHAND_API_KEY")
+
+    return (url or DEFAULT_URL, api_key)
+
+
+def _shared_config_path() -> Path | None:
+    """Discover the shared config.toml using the same order as Deckhand Core."""
+    explicit = os.getenv("DECKHAND_CONFIG_FILE")
+    if explicit and os.path.exists(explicit):
+        return Path(explicit)
+    if os.path.exists("config.toml"):
+        return Path("config.toml")
+    home = Path(os.path.expanduser("~/.config/deckhand/config.toml"))
+    if home.exists():
+        return home
+    return None
+
+
+def _load_shared_client_section() -> dict[str, str]:
+    """Parse the ``[client]`` section out of the shared config file.
+
+    Returns an empty dict if no config file is found, the file is
+    unparseable, or it has no ``[client]`` section. Errors are logged
+    but never raised — a malformed shared config must not prevent the
+    plugin from at least trying the legacy path or the env vars.
+    """
+    path = _shared_config_path()
+    if path is None:
+        return {}
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        logger.warning("Could not read shared config at %s: %s", path, exc)
+        return {}
+    client = data.get("client")
+    if not isinstance(client, dict):
+        return {}
+    result: dict[str, str] = {}
+    if isinstance(client.get("url"), str):
+        result["url"] = client["url"]
+    if isinstance(client.get("api_key"), str):
+        result["api_key"] = client["api_key"]
+    return result
+
+
+def _load_legacy_env_file(path: Path) -> dict[str, str] | None:
+    """Parse a deckhand.env-style file. Returns None if the file is absent."""
+    if not path.exists():
+        return None
+    values: dict[str, str] = {}
+    try:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            values[key.strip()] = value.strip().strip('"').strip("'")
+    except OSError as exc:
+        logger.warning("Could not read legacy deckhand.env at %s: %s", path, exc)
+        return None
+    return values

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/deckhand.env.example
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/deckhand.env.example
@@ -1,3 +1,9 @@
-# Copy to deckhand.env and set the same key as Deckhand Core (config.toml or .env).
-DECKHAND_API_KEY=your-write-key-here
-DECKHAND_URL=http://127.0.0.1:8000
+# DEPRECATED — kept for one release as a fallback for existing installs.
+#
+# New installs: put your values in the shared config.toml's [client] section
+# at ~/.config/deckhand/config.toml. The plugin logs a deprecation warning
+# whenever it falls back to deckhand.env. This file will be removed in the
+# release after #34. See ../README.md for the canonical setup.
+#
+# DECKHAND_API_KEY=your-write-key-here
+# DECKHAND_URL=http://127.0.0.1:8000

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/plugin.py
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/plugin.py
@@ -10,8 +10,7 @@ import argparse
 import asyncio
 import json
 import logging
-import os
-import sys
+from pathlib import Path
 from typing import Any
 
 import websockets
@@ -24,6 +23,7 @@ from actions.agent_status import AgentStatusHandler
 from actions.signal_trigger import SignalTriggerHandler
 from actions.widget import WidgetHandler
 from bridge import DeckhandBridge
+from client_config import resolve_connection
 from diagnostics import PluginDiagnostics
 
 logging.basicConfig(
@@ -49,12 +49,19 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Deckhand OpenDeck Plugin")
     parser.add_argument("-port", type=int, required=True, help="WebSocket port")
     parser.add_argument("-pluginUUID", type=str, required=True, help="Plugin UUID")
-    parser.add_argument("-registerEvent", type=str, required=True, help="Registration event name")
+    parser.add_argument(
+        "-registerEvent", type=str, required=True, help="Registration event name"
+    )
     parser.add_argument("-info", type=str, required=True, help="JSON info string")
     return parser.parse_args()
 
 
-async def send_to_opendeck(ws: websockets.asyncio.client.ClientConnection, event: str, context: str, payload: dict[str, Any] | None = None) -> None:
+async def send_to_opendeck(
+    ws: websockets.asyncio.client.ClientConnection,
+    event: str,
+    context: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
     """Send an event to OpenDeck."""
     msg: dict[str, Any] = {"event": event, "context": context}
     if payload is not None:
@@ -63,7 +70,11 @@ async def send_to_opendeck(ws: websockets.asyncio.client.ClientConnection, event
     diag.record_sent()
 
 
-async def handle_opendeck_event(ws: websockets.asyncio.client.ClientConnection, data: dict[str, Any], bridge: DeckhandBridge) -> None:
+async def handle_opendeck_event(
+    ws: websockets.asyncio.client.ClientConnection,
+    data: dict[str, Any],
+    bridge: DeckhandBridge,
+) -> None:
     """Dispatch an incoming OpenDeck event to the appropriate handler."""
     diag.record_opendeck_event()
 
@@ -106,11 +117,15 @@ async def handle_opendeck_event(ws: websockets.asyncio.client.ClientConnection, 
             # Handle diagnostics request from any PI
             if payload.get("type") == "getDiagnostics":
                 diag.deckhand_connected = bridge.connected
-                await ws.send(json.dumps({
-                    "event": "sendToPropertyInspector",
-                    "context": context,
-                    "payload": {"type": "diagnostics", "data": diag.as_dict()},
-                }))
+                await ws.send(
+                    json.dumps(
+                        {
+                            "event": "sendToPropertyInspector",
+                            "context": context,
+                            "payload": {"type": "diagnostics", "data": diag.as_dict()},
+                        }
+                    )
+                )
                 return
 
             handler = ACTION_HANDLERS.get(action)
@@ -122,7 +137,9 @@ async def handle_opendeck_event(ws: websockets.asyncio.client.ClientConnection, 
         logger.exception("Error handling OpenDeck event %s", event)
 
 
-async def handle_deckhand_event(ws: websockets.asyncio.client.ClientConnection, event: dict[str, Any]) -> None:
+async def handle_deckhand_event(
+    ws: websockets.asyncio.client.ClientConnection, event: dict[str, Any]
+) -> None:
     """Forward a Deckhand Core event to all relevant OpenDeck contexts."""
     diag.record_deckhand_event()
     event_type = event.get("type", "")
@@ -135,11 +152,14 @@ async def handle_deckhand_event(ws: websockets.asyncio.client.ClientConnection, 
             logger.exception("Error forwarding Deckhand event %s", event_type)
 
 
-async def deckhand_listener(ws: websockets.asyncio.client.ClientConnection, bridge: DeckhandBridge) -> None:
+async def deckhand_listener(
+    ws: websockets.asyncio.client.ClientConnection, bridge: DeckhandBridge
+) -> None:
     """Subscribe to Deckhand Core events and forward them.
 
     Reconnection is handled inside bridge.subscribe_events with exponential backoff.
     """
+
     async def on_event(event: dict[str, Any]) -> None:
         diag.deckhand_connected = True
         await handle_deckhand_event(ws, event)
@@ -150,12 +170,14 @@ async def deckhand_listener(ws: websockets.asyncio.client.ClientConnection, brid
 async def main() -> None:
     args = parse_args()
 
-    # Deckhand Core URL and auth: env var > default
-    core_url = os.getenv("DECKHAND_URL", "http://localhost:8000")
-    api_key = os.getenv("DECKHAND_API_KEY")
+    # Resolve connection settings: env var → [client] in shared config.toml
+    # → legacy deckhand.env (deprecated). See client_config.py for details.
+    core_url, api_key = resolve_connection(Path(__file__).parent)
     bridge = DeckhandBridge(base_url=core_url, api_key=api_key)
     info = json.loads(args.info) if args.info else {}
-    logger.info("Starting Deckhand plugin (port=%d, uuid=%s)", args.port, args.pluginUUID)
+    logger.info(
+        "Starting Deckhand plugin (port=%d, uuid=%s)", args.port, args.pluginUUID
+    )
     logger.info("Deckhand Core URL: %s", core_url)
     logger.info("OpenDeck info: %s", json.dumps(info, indent=2))
 
@@ -170,10 +192,12 @@ async def main() -> None:
     uri = f"ws://127.0.0.1:{args.port}"
     async with websockets.asyncio.client.connect(uri) as ws:
         # Register with OpenDeck
-        registration = json.dumps({
-            "event": args.registerEvent,
-            "uuid": args.pluginUUID,
-        })
+        registration = json.dumps(
+            {
+                "event": args.registerEvent,
+                "uuid": args.pluginUUID,
+            }
+        )
         await ws.send(registration)
         logger.info("Registered with OpenDeck")
 

--- a/opendeck-plugin/com.deckhand.plugin.sdPlugin/run.sh
+++ b/opendeck-plugin/com.deckhand.plugin.sdPlugin/run.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Load DECKHAND_URL and DECKHAND_API_KEY from deckhand.env (copy from deckhand.env.example).
-if [ -f "$DIR/deckhand.env" ]; then
-  set -a
-  # shellcheck disable=SC1091
-  source "$DIR/deckhand.env"
-  set +a
-fi
+# Connection settings (URL + API key) are resolved inside plugin.py — see
+# client_config.py. Order of precedence: DECKHAND_URL / DECKHAND_API_KEY env
+# vars → [client] section of the shared config.toml (./config.toml or
+# ~/.config/deckhand/config.toml) → legacy deckhand.env (deprecated).
 
 VENV="$DIR/.venv"
 if [ ! -x "$VENV/bin/python3" ]; then

--- a/opendeck-plugin/tests/test_client_config.py
+++ b/opendeck-plugin/tests/test_client_config.py
@@ -1,0 +1,173 @@
+"""Tests for the OpenDeck plugin's connection-config resolution.
+
+Verifies the precedence chain documented in client_config.py:
+env var → [client] in shared config.toml → legacy deckhand.env → defaults.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_DIR = Path(__file__).parent.parent / "com.deckhand.plugin.sdPlugin"
+sys.path.insert(0, str(PLUGIN_DIR))
+
+from client_config import DEFAULT_URL, resolve_connection  # noqa: E402
+
+
+def _isolate(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("DECKHAND_URL", "DECKHAND_API_KEY", "DECKHAND_CONFIG_FILE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_no_sources_returns_default_url_and_no_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    _isolate(monkeypatch)
+
+    url, api_key = resolve_connection(tmp_path / "no-plugin-here")
+    assert url == DEFAULT_URL
+    assert api_key is None
+
+
+def test_env_var_wins_over_everything(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Both [client] section and legacy deckhand.env are present, but the
+    env var still wins."""
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / "deckhand.env").write_text(
+        "DECKHAND_URL=http://legacy:1\nDECKHAND_API_KEY=legacy\n"
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.toml").write_text(
+        '[client]\nurl = "http://shared:2"\napi_key = "shared"\n'
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _isolate(monkeypatch)
+    monkeypatch.setenv("DECKHAND_URL", "http://env:3")
+    monkeypatch.setenv("DECKHAND_API_KEY", "env-key")
+
+    url, api_key = resolve_connection(plugin_dir)
+    assert url == "http://env:3"
+    assert api_key == "env-key"
+
+
+def test_shared_config_used_when_env_var_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No env vars, [client] section present in ./config.toml → use it."""
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.toml").write_text(
+        '[client]\nurl = "http://shared:4"\napi_key = "shared-key"\n'
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _isolate(monkeypatch)
+
+    url, api_key = resolve_connection(plugin_dir)
+    assert url == "http://shared:4"
+    assert api_key == "shared-key"
+
+
+def test_home_dir_config_used_when_no_project_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """OpenDeck-plugin-only install path: home-dir config carries [client]."""
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir()
+    fake_home = tmp_path / "home"
+    (fake_home / ".config" / "deckhand").mkdir(parents=True)
+    (fake_home / ".config" / "deckhand" / "config.toml").write_text(
+        '[client]\nurl = "http://home:5"\napi_key = "home-key"\n'
+    )
+    project = tmp_path / "project-no-config"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(fake_home))
+    _isolate(monkeypatch)
+
+    url, api_key = resolve_connection(plugin_dir)
+    assert url == "http://home:5"
+    assert api_key == "home-key"
+
+
+def test_legacy_env_file_used_when_no_env_or_shared_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog
+) -> None:
+    """The deprecated deckhand.env fallback fires when nothing else has the
+    values — and the plugin logs a deprecation warning."""
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / "deckhand.env").write_text(
+        "DECKHAND_URL=http://legacy:6\nDECKHAND_API_KEY=legacy-key\n"
+    )
+    project = tmp_path / "project-no-config"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _isolate(monkeypatch)
+
+    with caplog.at_level(logging.WARNING):
+        url, api_key = resolve_connection(plugin_dir)
+
+    assert url == "http://legacy:6"
+    assert api_key == "legacy-key"
+    assert any("deprecated" in r.message for r in caplog.records)
+
+
+def test_partial_env_var_is_filled_in_from_shared_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If only DECKHAND_URL is set in the environment, the api_key still
+    comes from the [client] section. Values resolve independently — they
+    don't have to come from the same tier."""
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.toml").write_text(
+        '[client]\nurl = "http://shared:7"\napi_key = "shared-key"\n'
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _isolate(monkeypatch)
+    monkeypatch.setenv("DECKHAND_URL", "http://env-only:8")
+
+    url, api_key = resolve_connection(plugin_dir)
+    assert url == "http://env-only:8"
+    assert api_key == "shared-key"
+
+
+def test_malformed_shared_config_is_logged_and_skipped(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog
+) -> None:
+    """A broken [client] TOML must not crash the plugin — it should log
+    the parse failure, skip the file, and try the next tier (legacy env
+    file → defaults)."""
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.toml").write_text("this is not [valid toml")
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _isolate(monkeypatch)
+
+    with caplog.at_level(logging.WARNING):
+        url, api_key = resolve_connection(plugin_dir)
+
+    assert url == DEFAULT_URL
+    assert api_key is None
+    assert any("Could not read shared config" in r.message for r in caplog.records)

--- a/opendeck-plugin/tests/test_plugin.py
+++ b/opendeck-plugin/tests/test_plugin.py
@@ -6,11 +6,10 @@ and verifies plugin event handling against a real Deckhand Core.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -18,14 +17,15 @@ import pytest
 PLUGIN_DIR = Path(__file__).parent.parent / "com.deckhand.plugin.sdPlugin"
 sys.path.insert(0, str(PLUGIN_DIR))
 
-from actions.agent_status import AgentStatusHandler, STATUS_INDEX
-from actions.widget import WidgetHandler, _format_value
-from bridge import DeckhandBridge
+from actions.agent_status import AgentStatusHandler, STATUS_INDEX  # noqa: E402
+from actions.widget import WidgetHandler, _format_value  # noqa: E402
+from bridge import DeckhandBridge  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_bridge():
@@ -35,20 +35,26 @@ def mock_bridge():
     bridge.ws_url = "ws://localhost:8000/events"
     bridge._session = None
 
-    bridge.list_agents = AsyncMock(return_value=[
-        {"id": "mock-1", "type": "mock", "status": "idle", "capabilities": []},
-        {"id": "mock-2", "type": "mock", "status": "running", "capabilities": []},
-    ])
+    bridge.list_agents = AsyncMock(
+        return_value=[
+            {"id": "mock-1", "type": "mock", "status": "idle", "capabilities": []},
+            {"id": "mock-2", "type": "mock", "status": "running", "capabilities": []},
+        ]
+    )
 
     bridge.start_agent = AsyncMock()
     bridge.cancel_agent = AsyncMock()
     bridge.provide_input = AsyncMock()
     bridge.execute_action = AsyncMock()
-    bridge.get_state = AsyncMock(return_value={"key": "test.key", "value": {"count": 42}})
-    bridge.list_state = AsyncMock(return_value=[
-        {"key": "test.key", "value": {"count": 42}},
-        {"key": "other.key", "value": {"active": True}},
-    ])
+    bridge.get_state = AsyncMock(
+        return_value={"key": "test.key", "value": {"count": 42}}
+    )
+    bridge.list_state = AsyncMock(
+        return_value=[
+            {"key": "test.key", "value": {"count": 42}},
+            {"key": "other.key", "value": {"active": True}},
+        ]
+    )
     bridge.close = AsyncMock()
     return bridge
 
@@ -75,8 +81,11 @@ def widget_handler(mock_bridge):
 # AgentStatusHandler tests
 # ---------------------------------------------------------------------------
 
+
 class TestAgentStatusHandler:
-    async def test_will_appear_fetches_status(self, agent_handler, mock_ws, mock_bridge):
+    async def test_will_appear_fetches_status(
+        self, agent_handler, mock_ws, mock_bridge
+    ):
         """willAppear should fetch agent list and set initial state."""
         await agent_handler.on_will_appear(mock_ws, "ctx-1", {"agent_id": "mock-1"})
 
@@ -103,12 +112,16 @@ class TestAgentStatusHandler:
         await agent_handler.on_will_disappear("ctx-1")
         assert "ctx-1" not in agent_handler._watched
 
-    async def test_key_down_starts_idle_agent(self, agent_handler, mock_ws, mock_bridge):
+    async def test_key_down_starts_idle_agent(
+        self, agent_handler, mock_ws, mock_bridge
+    ):
         """Pressing a button for an idle agent should start it."""
         await agent_handler.on_key_down(mock_ws, "ctx-1", {"agent_id": "mock-1"})
         mock_bridge.start_agent.assert_awaited_once_with("mock-1")
 
-    async def test_key_down_cancels_running_agent(self, agent_handler, mock_ws, mock_bridge):
+    async def test_key_down_cancels_running_agent(
+        self, agent_handler, mock_ws, mock_bridge
+    ):
         """Pressing a button for a running agent should cancel it."""
         mock_bridge.list_agents.return_value = [
             {"id": "mock-1", "type": "mock", "status": "running", "capabilities": []},
@@ -119,24 +132,38 @@ class TestAgentStatusHandler:
     async def test_key_down_provides_input(self, agent_handler, mock_ws, mock_bridge):
         """Pressing a button for awaiting_input agent should send input."""
         mock_bridge.list_agents.return_value = [
-            {"id": "mock-1", "type": "mock", "status": "awaiting_input", "capabilities": []},
+            {
+                "id": "mock-1",
+                "type": "mock",
+                "status": "awaiting_input",
+                "capabilities": [],
+            },
         ]
-        await agent_handler.on_key_down(mock_ws, "ctx-1", {
-            "agent_id": "mock-1",
-            "default_input": "yes",
-        })
+        await agent_handler.on_key_down(
+            mock_ws,
+            "ctx-1",
+            {
+                "agent_id": "mock-1",
+                "default_input": "yes",
+            },
+        )
         mock_bridge.provide_input.assert_awaited_once_with("mock-1", "yes")
 
     async def test_deckhand_event_updates_context(self, agent_handler, mock_ws):
         """agent.status_changed event should update watched contexts."""
         # Register a context watching mock-1
-        agent_handler._watched["ctx-1"] = {"agent_id": "mock-1", "sounds_enabled": False}
+        agent_handler._watched["ctx-1"] = {
+            "agent_id": "mock-1",
+            "sounds_enabled": False,
+        }
 
         event = {
             "type": "agent.status_changed",
             "payload": {"agent_id": "mock-1", "status": "running"},
         }
-        await agent_handler.on_deckhand_event(mock_ws, "agent.status_changed", event, {})
+        await agent_handler.on_deckhand_event(
+            mock_ws, "agent.status_changed", event, {}
+        )
 
         calls = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
         state_calls = [c for c in calls if c["event"] == "setState"]
@@ -144,13 +171,18 @@ class TestAgentStatusHandler:
 
     async def test_deckhand_event_ignores_unwatched_agent(self, agent_handler, mock_ws):
         """Events for unwatched agents should be ignored."""
-        agent_handler._watched["ctx-1"] = {"agent_id": "mock-1", "sounds_enabled": False}
+        agent_handler._watched["ctx-1"] = {
+            "agent_id": "mock-1",
+            "sounds_enabled": False,
+        }
 
         event = {
             "type": "agent.status_changed",
             "payload": {"agent_id": "mock-999", "status": "error"},
         }
-        await agent_handler.on_deckhand_event(mock_ws, "agent.status_changed", event, {})
+        await agent_handler.on_deckhand_event(
+            mock_ws, "agent.status_changed", event, {}
+        )
         mock_ws.send.assert_not_called()
 
     async def test_send_to_plugin_get_agents(self, agent_handler, mock_ws, mock_bridge):
@@ -168,10 +200,15 @@ class TestAgentStatusHandler:
 # WidgetHandler tests
 # ---------------------------------------------------------------------------
 
+
 class TestWidgetHandler:
-    async def test_will_appear_fetches_state(self, widget_handler, mock_ws, mock_bridge):
+    async def test_will_appear_fetches_state(
+        self, widget_handler, mock_ws, mock_bridge
+    ):
         """willAppear should fetch state and set title."""
-        await widget_handler.on_will_appear(mock_ws, "ctx-w1", {"state_key": "test.key"})
+        await widget_handler.on_will_appear(
+            mock_ws, "ctx-w1", {"state_key": "test.key"}
+        )
 
         mock_bridge.get_state.assert_awaited_once_with("test.key")
         calls = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
@@ -188,7 +225,9 @@ class TestWidgetHandler:
         title_calls = [c for c in calls if c["event"] == "setTitle"]
         assert title_calls[0]["payload"]["title"] == "No Key"
 
-    async def test_will_appear_missing_state(self, widget_handler, mock_ws, mock_bridge):
+    async def test_will_appear_missing_state(
+        self, widget_handler, mock_ws, mock_bridge
+    ):
         """willAppear with missing state key shows dash."""
         mock_bridge.get_state.return_value = None
         await widget_handler.on_will_appear(mock_ws, "ctx-w1", {"state_key": "nope"})
@@ -199,7 +238,9 @@ class TestWidgetHandler:
 
     async def test_key_down_executes_action(self, widget_handler, mock_ws, mock_bridge):
         """Key press executes configured action."""
-        await widget_handler.on_key_down(mock_ws, "ctx-w1", {"action_on_press": "lights.toggle"})
+        await widget_handler.on_key_down(
+            mock_ws, "ctx-w1", {"action_on_press": "lights.toggle"}
+        )
         mock_bridge.execute_action.assert_awaited_once_with("lights.toggle", {})
 
     async def test_key_down_no_action(self, widget_handler, mock_ws, mock_bridge):
@@ -243,6 +284,7 @@ class TestWidgetHandler:
 # _format_value tests
 # ---------------------------------------------------------------------------
 
+
 class TestFormatValue:
     def test_raw_string(self):
         assert _format_value("hello", "raw") == "hello"
@@ -272,16 +314,31 @@ class TestFormatValue:
 # AgentSlotHandler tests
 # ---------------------------------------------------------------------------
 
+
 class TestAgentSlotHandler:
     async def test_slot_binds_highest_priority(self, mock_ws, mock_bridge):
         from actions.agent_slot import AgentSlotHandler
 
         mock_bridge.list_agents.return_value = [
-            {"id": "cursor-aaa", "type": "cursor", "status": "running", "display_label": "proj", "updated_at": 2},
-            {"id": "cursor-bbb", "type": "cursor", "status": "awaiting_input", "display_label": "urgent", "updated_at": 1},
+            {
+                "id": "cursor-aaa",
+                "type": "cursor",
+                "status": "running",
+                "display_label": "proj",
+                "updated_at": 2,
+            },
+            {
+                "id": "cursor-bbb",
+                "type": "cursor",
+                "status": "awaiting_input",
+                "display_label": "urgent",
+                "updated_at": 1,
+            },
         ]
         handler = AgentSlotHandler(mock_bridge)
-        await handler.on_will_appear(mock_ws, "ctx-s1", {"slot_index": 1, "agent_filter": "cursor"})
+        await handler.on_will_appear(
+            mock_ws, "ctx-s1", {"slot_index": 1, "agent_filter": "cursor"}
+        )
 
         calls = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
         title_calls = [c for c in calls if c["event"] == "setTitle"]
@@ -291,10 +348,17 @@ class TestAgentSlotHandler:
         from actions.agent_slot import AgentSlotHandler
 
         mock_bridge.list_agents.return_value = [
-            {"id": "cursor-aaa", "type": "cursor", "status": "running", "updated_at": 1},
+            {
+                "id": "cursor-aaa",
+                "type": "cursor",
+                "status": "running",
+                "updated_at": 1,
+            },
         ]
         handler = AgentSlotHandler(mock_bridge)
-        await handler.on_key_down(mock_ws, "ctx-s1", {"slot_index": 1, "agent_filter": "cursor"})
+        await handler.on_key_down(
+            mock_ws, "ctx-s1", {"slot_index": 1, "agent_filter": "cursor"}
+        )
         mock_bridge.execute_action.assert_awaited_once_with(
             "ui.focus_cursor_agent",
             {"agent_id": "cursor-aaa"},
@@ -305,12 +369,18 @@ class TestAgentSlotHandler:
 # AgentDashboardHandler smart press
 # ---------------------------------------------------------------------------
 
+
 class TestAgentDashboardSmartPress:
     async def test_press_focuses_attention_agent(self, mock_ws, mock_bridge):
         from actions.agent_dashboard import AgentDashboardHandler
 
         mock_bridge.list_agents.return_value = [
-            {"id": "cursor-aaa", "type": "cursor", "status": "awaiting_input", "updated_at": 1},
+            {
+                "id": "cursor-aaa",
+                "type": "cursor",
+                "status": "awaiting_input",
+                "updated_at": 1,
+            },
         ]
         handler = AgentDashboardHandler(mock_bridge)
         await handler.on_key_down(mock_ws, "ctx-d1", {"agent_filter": "cursor"})

--- a/src/deckhand/cli/config.py
+++ b/src/deckhand/cli/config.py
@@ -3,8 +3,14 @@
 Precedence (highest first):
 1. CLI flags (``--url``, ``--api-key``)
 2. Environment variables (``DECKHAND_URL``, ``DECKHAND_API_KEY``, ``DECKHAND_EVENT_LOG``)
-3. ``config.toml`` ``[service]`` / ``[auth]`` / ``[event_log]``
-4. Built-in defaults
+3. ``config.toml`` ``[client]`` section (preferred — same field any other
+   Deckhand client reads from)
+4. ``config.toml`` ``[service]`` / ``[auth]`` legacy extraction (URL from
+   ``[service]`` host+port, key from ``[auth].api_keys[0]``)
+5. Built-in defaults
+
+Config file discovery matches Deckhand Core: ``DECKHAND_CONFIG_FILE`` env
+var → ``./config.toml`` → ``~/.config/deckhand/config.toml``.
 """
 
 from __future__ import annotations
@@ -38,23 +44,41 @@ def load(
     config_path = config_file or os.getenv("DECKHAND_CONFIG_FILE")
     if not config_path and Path("config.toml").exists():
         config_path = "config.toml"
+    if not config_path:
+        home_config = Path(os.path.expanduser("~/.config/deckhand/config.toml"))
+        if home_config.exists():
+            config_path = str(home_config)
 
     resolved_config_path: str | None = None
     if config_path and Path(config_path).exists():
         resolved_config_path = config_path
         config = load_config(config_path)
 
-        service = config.get("service", {})
-        host = service.get("host", "127.0.0.1")
-        port = service.get("port", 8000)
-        if host or port:
-            file_url = f"http://{host}:{port}"
+        # Preferred: explicit [client] section. Same shape any other
+        # Deckhand client reads from.
+        client_section = config.get("client", {})
+        if isinstance(client_section, dict):
+            if isinstance(client_section.get("url"), str):
+                file_url = client_section["url"]
+            if isinstance(client_section.get("api_key"), str):
+                file_key = client_section["api_key"]
 
-        auth = config.get("auth", {})
-        if isinstance(auth.get("api_keys"), list) and auth["api_keys"]:
-            first = auth["api_keys"][0]
-            if isinstance(first, dict) and "key" in first:
-                file_key = first["key"]
+        # Fallback: infer URL from the service's listen address and the
+        # key from the first entry of [auth].api_keys. Kept so existing
+        # configs that don't have a [client] section still work.
+        if file_url is None:
+            service = config.get("service", {})
+            host = service.get("host", "127.0.0.1")
+            port = service.get("port", 8000)
+            if host or port:
+                file_url = f"http://{host}:{port}"
+
+        if file_key is None:
+            auth = config.get("auth", {})
+            if isinstance(auth.get("api_keys"), list) and auth["api_keys"]:
+                first = auth["api_keys"][0]
+                if isinstance(first, dict) and "key" in first:
+                    file_key = first["key"]
 
         el = config.get("event_log", {})
         if isinstance(el.get("path"), str):

--- a/src/deckhand/config/settings.py
+++ b/src/deckhand/config/settings.py
@@ -76,10 +76,26 @@ class Settings:
         # Auth: list of {key, scope} dicts
         self._raw_api_keys: list[dict[str, str]] = []
 
-        # Load from config file: explicit env var, or auto-discover ./config.toml
+        # Config file discovery order (first hit wins):
+        #   1. DECKHAND_CONFIG_FILE env var (explicit override)
+        #   2. ./config.toml (project-rooted; works on every OS the same way)
+        #   3. ~/.config/deckhand/config.toml (XDG-style home fallback)
+        #
+        # The home fallback exists so OpenDeck-plugin-only users — who don't
+        # have a service checkout to drop a config.toml into — have one
+        # well-known place to put their shared `[client]` config. The same
+        # file is read by any other Deckhand client (CLI, OpenDeck plugin).
+        # `expanduser` resolves the path on every OS; on Windows it lands at
+        # ``C:\Users\<user>\.config\deckhand\config.toml`` — functional but
+        # non-canonical. A future Windows-targeting change can prepend an
+        # ``%APPDATA%`` check between steps 2 and 3 without disturbing this.
         config_file = os.getenv("DECKHAND_CONFIG_FILE")
         if not config_file and os.path.exists("config.toml"):
             config_file = "config.toml"
+        if not config_file:
+            home_config = os.path.expanduser("~/.config/deckhand/config.toml")
+            if os.path.exists(home_config):
+                config_file = home_config
         if config_file:
             self.config_file_path = config_file
             self._load_from_config_file(config_file)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -447,3 +447,77 @@ def test_config_file_only(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     cfg = cli_config.load()
     assert cfg.url == "http://1.2.3.4:1234"
     assert cfg.api_key == "file-key"
+
+
+def test_config_prefers_client_section_over_legacy_extraction(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The [client] section is the canonical place for client URL + key.
+    When present it wins over the legacy [service]/[auth] inference."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '[service]\nhost = "1.2.3.4"\nport = 1234\n'
+        '[auth]\napi_keys = [{ key = "auth-key", scope = "write" }]\n'
+        "[client]\n"
+        'url = "http://client:9999"\n'
+        'api_key = "client-key"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    for var in ("DECKHAND_URL", "DECKHAND_API_KEY", "DECKHAND_CONFIG_FILE"):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = cli_config.load()
+    assert cfg.url == "http://client:9999"
+    assert cfg.api_key == "client-key"
+
+
+def test_config_falls_back_to_home_dir_when_no_project_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With no ./config.toml and no DECKHAND_CONFIG_FILE, the CLI falls back
+    to ~/.config/deckhand/config.toml. This is the OpenDeck-plugin-only
+    install path: no service checkout, just a home-dir config."""
+    fake_home = tmp_path / "home"
+    home_config_dir = fake_home / ".config" / "deckhand"
+    home_config_dir.mkdir(parents=True)
+    (home_config_dir / "config.toml").write_text(
+        '[client]\nurl = "http://home:8000"\napi_key = "home-key"\n'
+    )
+
+    project_dir = tmp_path / "project-without-config"
+    project_dir.mkdir()
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("HOME", str(fake_home))
+    for var in ("DECKHAND_URL", "DECKHAND_API_KEY", "DECKHAND_CONFIG_FILE"):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = cli_config.load()
+    assert cfg.url == "http://home:8000"
+    assert cfg.api_key == "home-key"
+
+
+def test_config_project_toml_wins_over_home_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If both ./config.toml and ~/.config/deckhand/config.toml exist, the
+    project-local one wins. Same precedence as the service uses."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".config" / "deckhand").mkdir(parents=True)
+    (fake_home / ".config" / "deckhand" / "config.toml").write_text(
+        '[client]\nurl = "http://home:1"\napi_key = "home"\n'
+    )
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "config.toml").write_text(
+        '[client]\nurl = "http://project:2"\napi_key = "project"\n'
+    )
+
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("HOME", str(fake_home))
+    for var in ("DECKHAND_URL", "DECKHAND_API_KEY", "DECKHAND_CONFIG_FILE"):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = cli_config.load()
+    assert cfg.url == "http://project:2"
+    assert cfg.api_key == "project"

--- a/tests/test_settings_config_discovery.py
+++ b/tests/test_settings_config_discovery.py
@@ -1,0 +1,143 @@
+"""Tests for the config-file discovery order in deckhand.config.Settings.
+
+Order under test:
+1. ``DECKHAND_CONFIG_FILE`` env var (explicit override)
+2. ``./config.toml`` (project-rooted)
+3. ``~/.config/deckhand/config.toml`` (home-dir fallback)
+
+First hit wins; later candidates are not merged. See settings.py docstring
+on ``__init__`` for the rationale (OpenDeck-plugin-only installs).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deckhand.config.settings import Settings
+
+
+def _isolate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every DECKHAND_* env var that could leak from the dev shell."""
+    for var in (
+        "DECKHAND_CONFIG_FILE",
+        "DECKHAND_HOST",
+        "DECKHAND_PORT",
+        "DECKHAND_PLUGINS",
+        "DECKHAND_API_KEY",
+        "DECKHAND_STATE_FILE",
+        "DECKHAND_RATE_LIMIT_RPM",
+        "DECKHAND_LOG_LEVEL",
+        "DECKHAND_LOG_FORMAT",
+        "DECKHAND_EVENT_LOG_ENABLED",
+        "DECKHAND_EVENT_LOG",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_no_config_file_uses_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(fake_home))
+    _isolate(monkeypatch)
+
+    settings = Settings()
+    assert settings.config_file_path is None
+    assert settings.host == "127.0.0.1"
+    assert settings.port == 8000
+
+
+def test_project_config_toml_is_picked_up(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.toml").write_text(
+        '[service]\nhost = "from-project"\nport = 1111\n'
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _isolate(monkeypatch)
+
+    settings = Settings()
+    assert settings.config_file_path == "config.toml"
+    assert settings.host == "from-project"
+    assert settings.port == 1111
+
+
+def test_home_dir_config_is_picked_up_when_no_project_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """OpenDeck-plugin-only install: no service checkout, just a home-dir
+    config.toml. The Settings loader should find it."""
+    fake_home = tmp_path / "home"
+    home_config_dir = fake_home / ".config" / "deckhand"
+    home_config_dir.mkdir(parents=True)
+    home_config = home_config_dir / "config.toml"
+    home_config.write_text('[service]\nhost = "from-home"\nport = 2222\n')
+
+    project = tmp_path / "project-without-config"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(fake_home))
+    _isolate(monkeypatch)
+
+    settings = Settings()
+    assert settings.config_file_path == str(home_config)
+    assert settings.host == "from-home"
+    assert settings.port == 2222
+
+
+def test_project_config_wins_over_home_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If both exist, the project-local config wins. No merging."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".config" / "deckhand").mkdir(parents=True)
+    (fake_home / ".config" / "deckhand" / "config.toml").write_text(
+        '[service]\nhost = "from-home"\nport = 1\n'
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.toml").write_text('[service]\nhost = "from-project"\nport = 2\n')
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(fake_home))
+    _isolate(monkeypatch)
+
+    settings = Settings()
+    assert settings.config_file_path == "config.toml"
+    assert settings.host == "from-project"
+
+
+def test_explicit_env_var_wins_over_both(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_home = tmp_path / "home"
+    (fake_home / ".config" / "deckhand").mkdir(parents=True)
+    (fake_home / ".config" / "deckhand" / "config.toml").write_text(
+        '[service]\nhost = "from-home"\n'
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "config.toml").write_text('[service]\nhost = "from-project"\n')
+
+    explicit = tmp_path / "explicit.toml"
+    explicit.write_text('[service]\nhost = "from-explicit"\nport = 9999\n')
+
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(fake_home))
+    _isolate(monkeypatch)
+    monkeypatch.setenv("DECKHAND_CONFIG_FILE", str(explicit))
+
+    settings = Settings()
+    assert settings.config_file_path == str(explicit)
+    assert settings.host == "from-explicit"
+    assert settings.port == 9999


### PR DESCRIPTION
Closes the gap between the README's "single config file" promise and the reality that OpenDeck-plugin users had to maintain a second one (`deckhand.env`) on top of `config.toml`. Three Deckhand surfaces — service, CLI, OpenDeck plugin — now all read from the same `config.toml` with the same discovery order.

## Investigation finding folded into scope

The ticket assumed `~/.config/deckhand/config.toml` was already a thing the service used — it wasn't. Deckhand Core looked at `DECKHAND_CONFIG_FILE` env var, then `./config.toml`, and stopped. So delivering on "one config file" required adding the XDG fallback to the core, not just a plugin-side change. Recorded in detail on the ticket's investigation comment.

## What ships

**Shared discovery order** — implemented identically across service (`Settings`), CLI (`cli.config`), and OpenDeck plugin (`client_config`):

1. `DECKHAND_CONFIG_FILE` env var
2. `./config.toml`
3. `~/.config/deckhand/config.toml` (via `os.path.expanduser` — no `sys.platform` branch; Windows lands functionally but non-canonically, a future Windows ticket can prepend `%APPDATA%` without disturbing this code)

**New `[client]` section** in `config.toml` carrying `url` and `api_key` — the canonical source for any Deckhand client. Service ignores this section. CLI prefers it over the legacy `[service]`-host/port + `[auth].api_keys[0]` inference (kept as fallback so existing configs keep working). OpenDeck plugin reads it as tier 2 of its own precedence chain.

**OpenDeck plugin precedence** — new `client_config.resolve_connection(plugin_dir)`:

1. `DECKHAND_URL` / `DECKHAND_API_KEY` env vars
2. `[client]` from the shared `config.toml`
3. Legacy `deckhand.env` next to `plugin.py` — logs a deprecation warning when used, scheduled for removal in the release after this one

`run.sh` no longer sources `deckhand.env`; resolution happens entirely in `plugin.py`. `deckhand.env.example` carries a deprecation banner.

## Other changes

- `Makefile`: `SRC_DIRS` and the `test` target now include `opendeck-plugin/` so the plugin module and its tests stay under the lint + test gate. Plugin tests run as a second pytest invocation with `--rootdir=opendeck-plugin` to avoid the `tests` package-name collision.
- Pre-existing format drift in 8 plugin source files (untouched by lint until now) was applied in one `ruff format` pass. Formatting-only, no behavioral changes.
- Pre-existing F401/E402 fixes in `opendeck-plugin/tests/test_plugin.py` and a stray unused `import sys` removal in `plugin.py`.
- READMEs updated: install steps no longer mention `deckhand.env` in the happy path; the env-var table notes the XDG fallback; `config.example.toml` documents discovery order at the top.

## Test plan

- `make check` — 216 server tests + 33 plugin tests pass, lint clean.
- `tests/test_settings_config_discovery.py` (new, 5 tests): the three-tier server-side discovery order — defaults when no file, project pickup, home-dir pickup, project wins over home, explicit env var wins over both.
- `tests/test_cli.py` (+3 tests): `[client]` section wins over legacy `[service]`/`[auth]` extraction; XDG fallback for the CLI; project `./config.toml` wins over home-dir.
- `opendeck-plugin/tests/test_client_config.py` (new, 7 tests): no sources → defaults; env var wins over everything; shared config used when env missing; home-dir fallback works; legacy `deckhand.env` fallback fires *and* logs the deprecation warning; partial env var fills in missing fields from shared config; malformed TOML is logged and skipped without crashing.

Manual real-Stream-Deck verification was flagged by the ticket as expected — that's a manual step done outside `make check`.

Closes #34
