### PR TITLE
Audit unreleased 1.0.0 CHANGELOG against current repo state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to Deckhand will be documented in this file.
 
 - **Documentation**
   - Plugin author guide (`docs/PLUGIN_GUIDE.md`)
-  - Stream Deck client integration guide (`docs/STREAMDECK_CLIENT.md`)
+  - Cursor Stream Deck profiles guide (`docs/CURSOR_STREAM_DECK_PROFILES.md`)
   - Complete API reference (`docs/API.md`)
   - Event schema reference (`docs/EVENTS.md`)
   - Reference hook configurations (`examples/claude_code_hooks.json`, `examples/cursor_hooks.json`)


### PR DESCRIPTION
Audits the unreleased `[1.0.0]` section of `CHANGELOG.md` against the actual repo tree (follow-up from PR #35's third review round).

- Removes the stale `docs/STREAMDECK_CLIENT.md` entry — file was deleted in 74744fa.
- Adds `docs/CURSOR_STREAM_DECK_PROFILES.md`, which ships in 1.0.0 but was previously unlisted.
- Verified the remaining four documentation entries (`PLUGIN_GUIDE.md`, `API.md`, `EVENTS.md`, `examples/claude_code_hooks.json`, `examples/cursor_hooks.json`) all exist on disk.
- `docs/opendeck-*.json` files are internal config catalogs (not user-facing docs) and are intentionally not listed.
- Confirmed no other stale `STREAMDECK_CLIENT` / `example_plugin` / `streamdeck_client_template` references remain anywhere in the repo.

Closes #36
